### PR TITLE
fix: update goreleaser config to resolve 404 errors and deprecation warnings

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,10 +30,10 @@ builds:
 
 archives:
   - id: lambda
-    builds:
-      - lambda
-    formats: ["zip"]
+    format: zip
     name_template: "{{ .ProjectName }}_lambda_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - none*
 
 snapshot:
   version_template: "{{ .Tag }}-next"
@@ -43,8 +43,8 @@ checksum:
 release:
   draft: false
   github:
-    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
-    name: "{{ .ProjectName }}"
+    owner: boogy
+    name: aws-oidc-warden
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Changes

- Fix GitHub repository owner and name configuration to resolve 404 errors during release
- Update archives format to resolve deprecation warning from GoReleaser v2
- Remove deprecated builds reference from archives section

## Testing

This should resolve the following issues:
- ❌ 404 Not Found error when creating releases
- ❌ Deprecation warning about `archives.builds` 

## Related Issues

Fixes the GoReleaser workflow failures in GitHub Actions.