### PR TITLE
fix: replace deprecated 'builds' with 'ids' in goreleaser archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,7 +74,7 @@ builds:
 
 archives:
   - id: apigateway
-    builds:
+    ids:
       - apigateway
     formats: ["zip"]
     name_template: "{{ .ProjectName }}_apigateway_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -83,7 +83,7 @@ archives:
         dst: bootstrap
 
   - id: alb
-    builds:
+    ids:
       - alb
     formats: ["zip"]
     name_template: "{{ .ProjectName }}_alb_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -92,7 +92,7 @@ archives:
         dst: bootstrap
 
   - id: lambdaurl
-    builds:
+    ids:
       - lambdaurl
     formats: ["zip"]
     name_template: "{{ .ProjectName }}_lambdaurl_{{ .Version }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
## Summary

This PR fixes the GoReleaser deprecation warning by replacing the deprecated `builds` field with `ids` in all archive configurations.

## Changes Made

- Replace deprecated `builds` field with `ids` in all three archive configurations (apigateway, alb, lambdaurl)
- Fixes GoReleaser deprecation warning: `archives.builds should not be used anymore`
- This change aligns with GoReleaser v2.8+ syntax requirements

## Technical Details

The `builds` field was deprecated in GoReleaser v2.8 in favor of `ids` to maintain consistent nomenclature across the configuration file. This change is purely syntactic - all functionality remains exactly the same.

### Before:
```yaml
archives:
  - id: apigateway
    builds:
      - apigateway
```

### After:
```yaml
archives:
  - id: apigateway
    ids:
      - apigateway
```

## Testing

- ✅ `goreleaser check` passes without warnings
- ✅ `goreleaser build --snapshot --clean` succeeds
- ✅ All build targets (apigateway, alb, lambdaurl) build successfully
- ✅ Archive generation works as expected

## References

- [GoReleaser Deprecation Documentation](https://goreleaser.com/deprecations#archivesbuilds)
- GoReleaser v2.8+ syntax requirements

This is a low-risk maintenance update that modernizes our build config- Thion without changing any functionality.