### PR TITLE
feat: short aow/repo tags via tag_auth.default_org

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -49,6 +49,7 @@ Optional, disabled by default. When enabled, a repo may assume a role whose IAM 
 | ------------------------------------- | -------------------------------- | ------------------------------------------------------- | ----------- |
 | `AOW_TAG_AUTH_ENABLED`                | `tag_auth.enabled`               | Enable tag-based authorization + cross-account assume   | `false`     |
 | `AOW_TAG_AUTH_TAG_PREFIX`             | `tag_auth.tag_prefix`            | Namespace prefix for authorization tag keys             | `aow/`      |
+| `AOW_TAG_AUTH_DEFAULT_ORG`            | `tag_auth.default_org`           | Org prefix for bare `aow/repo` tokens (e.g. `"api"` → `"<org>/api"`); empty = no expansion | (empty) |
 | `AOW_TAG_AUTH_SPOKE_ROLE_NAME`        | `tag_auth.spoke_role_name`       | Role assumed in each member account for cross-account   | `aow-spoke` |
 | `AOW_TAG_AUTH_EXTERNAL_ID`            | `tag_auth.external_id`           | Optional external ID for the hub→spoke trust            |             |
 | `AOW_TAG_AUTH_SPOKE_SESSION_DURATION` | `tag_auth.spoke_session_duration`| Hub→spoke session length                                | `15m`       |

--- a/docs/TAG_BASED_AUTHORIZATION.md
+++ b/docs/TAG_BASED_AUTHORIZATION.md
@@ -118,6 +118,46 @@ aow/event-name:  "push"
 is assumable by `acme/api` **or** `acme/web`, only on a `push` whose ref is
 exactly `refs/heads/main`.
 
+### Short-form repo tags (`default_org`)
+
+By default, every token in `aow/repo` must be a full `owner/repo` path — a bare
+name like `api` (no `/`) never matches the `repository` claim (which is always
+`owner/repo`).
+
+Set `tag_auth.default_org` to an org name to enable expansion: bare tokens are
+prefixed with `<default_org>/` before matching. Full `owner/repo` tokens are
+**not** expanded and continue to work as-is — they may name any org (multi-org
+use case).
+
+**Example** — with `tag_auth.default_org: acme`:
+
+```
+aow/repo: "api web"          # expands to acme/api and acme/web
+aow/repo: "beta/service api" # beta/service stays as-is; api expands to acme/api
+```
+
+Rules:
+
+- A token is "bare" if it contains no `/` character.
+- Expansion applies **only** to `aow/repo`. `aow/workflow-ref` always requires
+  the full `owner/repo/.github/workflows/x.yml@ref` form.
+- Matching remains **case-sensitive**. `default_org` must match the `repository`
+  claim's owner casing exactly (GitHub usernames and org names are
+  case-preserving).
+- Without `default_org` (empty string, the default), bare tokens never match —
+  the behavior is unchanged from before this feature was introduced.
+- Benefit: single-org fleets can use short names in role tags, staying well within
+  the AWS 256-character tag-value limit.
+
+**Token expansion examples** (`default_org: acme`):
+
+| Tag token    | Expanded form  | Matches claim `acme/api`? | Matches claim `beta/web`? |
+| ------------ | -------------- | ------------------------- | ------------------------- |
+| `api`        | `acme/api`     | yes                       | no                        |
+| `acme/api`   | `acme/api`     | yes                       | no                        |
+| `beta/web`   | `beta/web`     | no                        | yes                       |
+| `acme/`      | `acme/`        | no (exact, not a repo)    | no                        |
+
 ---
 
 ## Precedence: mappings + tags together
@@ -443,6 +483,7 @@ Example spoke trust policy (external ID optional):
 tag_auth:
   enabled: true
   tag_prefix: "aow/"
+  default_org: ""    # if set, bare aow/repo tags (e.g. "api") expand to "<default_org>/api"
   spoke_role_name: "aow-spoke"
   external_id: "" # optional
   spoke_session_duration: "15m"
@@ -451,6 +492,6 @@ tag_auth:
 ```
 
 Or via environment variables: `AOW_TAG_AUTH_ENABLED`, `AOW_TAG_AUTH_TAG_PREFIX`,
-`AOW_TAG_AUTH_SPOKE_ROLE_NAME`, `AOW_TAG_AUTH_EXTERNAL_ID`,
+`AOW_TAG_AUTH_DEFAULT_ORG`, `AOW_TAG_AUTH_SPOKE_ROLE_NAME`, `AOW_TAG_AUTH_EXTERNAL_ID`,
 `AOW_TAG_AUTH_SPOKE_SESSION_DURATION`, `AOW_TAG_AUTH_TRANSITIVE_SESSION_TAGS`,
 `AOW_TAG_AUTH_ALLOWED_ACCOUNTS` (comma-separated account IDs).

--- a/docs/TAG_BASED_AUTHORIZATION.md
+++ b/docs/TAG_BASED_AUTHORIZATION.md
@@ -151,7 +151,7 @@ Rules:
 
 **Token expansion examples** (`default_org: acme`):
 
-| Tag token    | Expanded form  | Matches claim `acme/api`? | Matches claim `beta/web`? |
+| Tag token    | Comparison form | Matches claim `acme/api`? | Matches claim `beta/web`? |
 | ------------ | -------------- | ------------------------- | ------------------------- |
 | `api`        | `acme/api`     | yes                       | no                        |
 | `acme/api`   | `acme/api`     | yes                       | no                        |

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -343,6 +343,7 @@ repo_role_mappings:
 tag_auth:
   enabled: false
   tag_prefix: "aow/" # tag key namespace; keys: aow/repo, aow/repo-owner, aow/branch, aow/ref, aow/ref-type, aow/event-name, aow/workflow-ref, aow/environment, aow/actor
+  default_org: "" # if set, bare aow/repo tags (e.g. "api") expand to "<default_org>/api"
   spoke_role_name: "aow-spoke" # role assumed in each member account (must trust the warden's execution role)
   external_id: "" # optional external ID for the hub->spoke trust
   spoke_session_duration: "15m"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -477,24 +477,29 @@ func (c *Config) Validate() error {
 
 	// Normalize tag-auth defaults so the feature works even when Config is built
 	// directly (e.g. in tests) without going through viper defaults.
-	if c.TagAuth != nil && c.TagAuth.Enabled {
-		if c.TagAuth.TagPrefix == "" {
-			c.TagAuth.TagPrefix = "aow/"
+	if c.TagAuth != nil {
+		if c.TagAuth.DefaultOrg != "" && strings.ContainsAny(c.TagAuth.DefaultOrg, "/ \t\n\r") {
+			return fmt.Errorf("tag_auth.default_org %q must not contain '/' or whitespace", c.TagAuth.DefaultOrg)
 		}
-		if c.TagAuth.SpokeRoleName == "" {
-			c.TagAuth.SpokeRoleName = "aow-spoke"
-		}
-		if c.TagAuth.SpokeSessionDuration == 0 {
-			c.TagAuth.SpokeSessionDuration = 15 * time.Minute
-		}
-		for i, acct := range c.TagAuth.AllowedAccounts {
-			c.TagAuth.AllowedAccounts[i] = strings.TrimSpace(acct)
-			if !accountIDPattern.MatchString(c.TagAuth.AllowedAccounts[i]) {
-				return fmt.Errorf("tag_auth.allowed_accounts entry %q is not a 12-digit AWS account ID", acct)
+		if c.TagAuth.Enabled {
+			if c.TagAuth.TagPrefix == "" {
+				c.TagAuth.TagPrefix = "aow/"
 			}
-		}
-		if len(c.TagAuth.AllowedAccounts) == 0 {
-			slog.Warn("tag_auth enabled with empty allowed_accounts; the warden may assume into ANY member account. Populate tag_auth.allowed_accounts in production.")
+			if c.TagAuth.SpokeRoleName == "" {
+				c.TagAuth.SpokeRoleName = "aow-spoke"
+			}
+			if c.TagAuth.SpokeSessionDuration == 0 {
+				c.TagAuth.SpokeSessionDuration = 15 * time.Minute
+			}
+			for i, acct := range c.TagAuth.AllowedAccounts {
+				c.TagAuth.AllowedAccounts[i] = strings.TrimSpace(acct)
+				if !accountIDPattern.MatchString(c.TagAuth.AllowedAccounts[i]) {
+					return fmt.Errorf("tag_auth.allowed_accounts entry %q is not a 12-digit AWS account ID", acct)
+				}
+			}
+			if len(c.TagAuth.AllowedAccounts) == 0 {
+				slog.Warn("tag_auth enabled with empty allowed_accounts; the warden may assume into ANY member account. Populate tag_auth.allowed_accounts in production.")
+			}
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,6 +76,7 @@ type TagAuth struct {
 	TagPrefix            string        `mapstructure:"tag_prefix"             json:"tag_prefix,omitempty"`             // default "aow/"
 	SpokeRoleName        string        `mapstructure:"spoke_role_name"        json:"spoke_role_name,omitempty"`        // default "aow-spoke"
 	ExternalID           string        `mapstructure:"external_id"            json:"external_id,omitempty"`            // optional hub->spoke external ID
+	DefaultOrg           string        `mapstructure:"default_org"            json:"default_org,omitempty"`            // prepended to bare aow/repo tag values: "api" -> "<default_org>/api"
 	SpokeSessionDuration time.Duration `mapstructure:"spoke_session_duration" json:"spoke_session_duration,omitempty"` // hub->spoke session length, default 15m
 
 	// TransitiveSessionTags, when true, marks the repo/ref/actor session tags
@@ -185,6 +186,7 @@ func (c *Config) LoadConfig() error {
 	_ = viper.BindEnv("tag_auth.tag_prefix")              // AOW_TAG_AUTH_TAG_PREFIX
 	_ = viper.BindEnv("tag_auth.spoke_role_name")         // AOW_TAG_AUTH_SPOKE_ROLE_NAME
 	_ = viper.BindEnv("tag_auth.external_id")             // AOW_TAG_AUTH_EXTERNAL_ID
+	_ = viper.BindEnv("tag_auth.default_org")             // AOW_TAG_AUTH_DEFAULT_ORG
 	_ = viper.BindEnv("tag_auth.spoke_session_duration")  // AOW_TAG_AUTH_SPOKE_SESSION_DURATION
 	_ = viper.BindEnv("tag_auth.transitive_session_tags") // AOW_TAG_AUTH_TRANSITIVE_SESSION_TAGS
 	_ = viper.BindEnv("tag_auth.allowed_accounts")        // AOW_TAG_AUTH_ALLOWED_ACCOUNTS (comma-separated)
@@ -338,6 +340,7 @@ func reapplyEnvOverrides(c *Config) {
 			{"AOW_TAG_AUTH_TAG_PREFIX", &c.TagAuth.TagPrefix},
 			{"AOW_TAG_AUTH_SPOKE_ROLE_NAME", &c.TagAuth.SpokeRoleName},
 			{"AOW_TAG_AUTH_EXTERNAL_ID", &c.TagAuth.ExternalID},
+			{"AOW_TAG_AUTH_DEFAULT_ORG", &c.TagAuth.DefaultOrg},
 		} {
 			if v := os.Getenv(f.env); v != "" {
 				*f.ptr = v

--- a/pkg/config/config_env_test.go
+++ b/pkg/config/config_env_test.go
@@ -80,6 +80,24 @@ func TestMergeBytes_EnvAudiencesTrimsWhitespace(t *testing.T) {
 	assert.Equal(t, []string{"a", "b"}, c.Audiences, "AOW_AUDIENCES elements must be whitespace-trimmed")
 }
 
+func TestMergeBytes_EnvTagAuthDefaultOrgWinsOverS3(t *testing.T) {
+	t.Setenv("AOW_TAG_AUTH_DEFAULT_ORG", "env-org")
+
+	c := &Config{
+		Issuer:          "https://token.actions.githubusercontent.com",
+		Audiences:       []string{"sts.amazonaws.com"},
+		RoleSessionName: "base-session",
+		Cache:           &Cache{Type: "memory", TTL: 5 * time.Minute},
+		TagAuth:         &TagAuth{Enabled: true, TagPrefix: "aow/", DefaultOrg: "base-org"},
+	}
+	require.NoError(t, c.Validate())
+
+	// S3 payload tries to override default_org; the env var must win.
+	require.NoError(t, c.MergeBytes([]byte("tag_auth:\n  default_org: s3-org\n"), "yaml"))
+
+	assert.Equal(t, "env-org", c.TagAuth.DefaultOrg, "AOW_TAG_AUTH_DEFAULT_ORG must take precedence over S3 value")
+}
+
 func TestMergeBytes_EnvCacheTTLWinsOverS3(t *testing.T) {
 	t.Setenv("AOW_CACHE_TTL", "10m")
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -517,6 +517,16 @@ func TestValidate_TagAuthDefaultOrg(t *testing.T) {
 	require.Error(t, base("acme/api").Validate())
 	require.Error(t, base("acme org").Validate())
 	require.Error(t, base("acme\torg").Validate())
+	require.Error(t, base("acme\norg").Validate())
+	require.Error(t, base("acme\rorg").Validate())
+
+	// default_org is validated even when tag-auth is disabled (ungated check).
+	require.Error(t, (&Config{
+		Issuer:          "https://token.actions.githubusercontent.com",
+		Audiences:       []string{"sts.amazonaws.com"},
+		RoleSessionName: "aow",
+		TagAuth:         &TagAuth{Enabled: false, DefaultOrg: "bad/org"},
+	}).Validate())
 }
 
 func TestTagAuthDefaults(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -503,6 +503,22 @@ func strPtr(s string) *string {
 	return &s
 }
 
+func TestValidate_TagAuthDefaultOrg(t *testing.T) {
+	base := func(org string) *Config {
+		return &Config{
+			Issuer:          "https://token.actions.githubusercontent.com",
+			Audiences:       []string{"sts.amazonaws.com"},
+			RoleSessionName: "aow",
+			TagAuth:         &TagAuth{Enabled: true, TagPrefix: "aow/", DefaultOrg: org},
+		}
+	}
+	require.NoError(t, base("acme").Validate())
+	require.NoError(t, base("").Validate())
+	require.Error(t, base("acme/api").Validate())
+	require.Error(t, base("acme org").Validate())
+	require.Error(t, base("acme\torg").Validate())
+}
+
 func TestTagAuthDefaults(t *testing.T) {
 	viper.Reset()
 	once = sync.Once{}

--- a/pkg/config/tagauth.go
+++ b/pkg/config/tagauth.go
@@ -36,7 +36,7 @@ func (t *TagAuth) Authorize(roleTags map[string]string, claims map[string]any) b
 	if !hasRepo && !hasOwner {
 		return false
 	}
-	identityOK := (hasRepo && valueInList(claim("repository"), repoTag)) ||
+	identityOK := (hasRepo && repoMatches(claim("repository"), repoTag, t.DefaultOrg)) ||
 		(hasOwner && valueInList(claim("repository_owner"), ownerTag))
 	if !identityOK {
 		return false
@@ -79,6 +79,29 @@ func valueInList(claimVal, tagVal string) bool {
 	}
 	for _, want := range strings.Fields(tagVal) {
 		if claimVal == want {
+			return true
+		}
+	}
+	return false
+}
+
+// repoMatches reports whether claimRepo matches the aow/repo tag value.
+// Each space-separated token that contains no "/" is treated as a bare repo
+// name and expanded to "<defaultOrg>/<token>" before comparison; tokens
+// already in org/repo form match as-is. When defaultOrg is empty, bare tokens
+// never match. Matching is exact (AWS tag charset has no regex).
+func repoMatches(claimRepo, tagVal, defaultOrg string) bool {
+	if claimRepo == "" {
+		return false
+	}
+	for _, want := range strings.Fields(tagVal) {
+		if !strings.Contains(want, "/") {
+			if defaultOrg == "" {
+				continue
+			}
+			want = defaultOrg + "/" + want
+		}
+		if claimRepo == want {
 			return true
 		}
 	}

--- a/pkg/config/tagauth_test.go
+++ b/pkg/config/tagauth_test.go
@@ -52,3 +52,37 @@ func TestTagAuth_Authorize_Disabled(t *testing.T) {
 	ta := &config.TagAuth{Enabled: false, TagPrefix: "aow/"}
 	assert.False(t, ta.Authorize(map[string]string{"aow/repo": "acme/api"}, map[string]any{"repository": "acme/api"}))
 }
+
+func TestTagAuth_Authorize_DefaultOrg(t *testing.T) {
+	ta := &config.TagAuth{Enabled: true, TagPrefix: "aow/", DefaultOrg: "acme"}
+	claims := map[string]any{"repository": "acme/api", "repository_owner": "acme"}
+	cases := []struct {
+		name string
+		tags map[string]string
+		want bool
+	}{
+		{"bare expands to default org", map[string]string{"aow/repo": "api"}, true},
+		{"bare wrong repo", map[string]string{"aow/repo": "web"}, false},
+		{"bare list one matches", map[string]string{"aow/repo": "web api"}, true},
+		{"full form still works", map[string]string{"aow/repo": "acme/api"}, true},
+		{"full form other org allowed", map[string]string{"aow/repo": "beta/web acme/api"}, true},
+		{"bare 'org/' token never matches", map[string]string{"aow/repo": "acme/"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, ta.Authorize(c.tags, claims))
+		})
+	}
+
+	// Security property: a bare token is org-scoped and must NOT match a repo of
+	// the same name in a different org. claim org (beta) != default_org (acme).
+	otherOrgClaims := map[string]any{"repository": "beta/api", "repository_owner": "beta"}
+	assert.False(t, ta.Authorize(map[string]string{"aow/repo": "api"}, otherOrgClaims))
+	// ...but the explicit full form for that other org still authorizes (lenient).
+	assert.True(t, ta.Authorize(map[string]string{"aow/repo": "beta/api"}, otherOrgClaims))
+
+	// No default_org: bare tokens must not match (current behavior preserved).
+	taNoOrg := &config.TagAuth{Enabled: true, TagPrefix: "aow/"}
+	assert.False(t, taNoOrg.Authorize(map[string]string{"aow/repo": "api"}, claims))
+	assert.True(t, taNoOrg.Authorize(map[string]string{"aow/repo": "acme/api"}, claims))
+}

--- a/pkg/config/tagauth_test.go
+++ b/pkg/config/tagauth_test.go
@@ -81,6 +81,9 @@ func TestTagAuth_Authorize_DefaultOrg(t *testing.T) {
 	// ...but the explicit full form for that other org still authorizes (lenient).
 	assert.True(t, ta.Authorize(map[string]string{"aow/repo": "beta/api"}, otherOrgClaims))
 
+	// Empty repository claim never matches, even with default_org set.
+	assert.False(t, ta.Authorize(map[string]string{"aow/repo": "api"}, map[string]any{}))
+
 	// No default_org: bare tokens must not match (current behavior preserved).
 	taNoOrg := &config.TagAuth{Enabled: true, TagPrefix: "aow/"}
 	assert.False(t, taNoOrg.Authorize(map[string]string{"aow/repo": "api"}, claims))


### PR DESCRIPTION
## Summary

Optional `tag_auth.default_org`: lets `aow/repo` IAM tags use a **bare repo name** (e.g. `api`) instead of full `org/repo` (e.g. `acme/api`), by prepending a configured org at match time. Saves characters against AWS's 256-char tag-value limit for single-org fleets, and tightens security — a bare tag can only ever resolve within the configured org.

## Behavior
- `default_org: acme` + role tag `aow/repo: "api web"` → authorizes `acme/api` and `acme/web`.
- Full `org/repo` tokens pass through unchanged and may name other orgs (multi-org stays supported); only bare names are expanded.
- Unset/empty `default_org` ⇒ bare tokens never match — **behavior identical to before** (existing `aow/repo` tags always carry `/`).
- Exact, case-sensitive match (AWS tag charset, no regex). Applies only to `aow/repo`, not `aow/workflow-ref`.
- `default_org` containing `/` or whitespace is rejected at config load (even when tag-auth disabled); a malformed value pushed via S3 fails `Validate`, so the provider keeps last-good config.

## Test plan
- `make check` green (fmt, 0 lint, all tests).
- New tests: env precedence on S3 reload, format validation (incl. newline/CR + disabled-config), matching table (bare/full/multi-org/cross-org-deny/empty-claim/no-default-org).
- Whole-branch security review: no cross-org bypass, no fail-open, prior `allowed_accounts` controls preserved.

## Stack
⚠️ Stacked on **#233** (`feature/transitive-tags-allowlist`). Retargets to `main` once the lower PRs land. Full order: #230 → #232 → #233 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
