### PR TITLE
feat: delegated JWT validation via API Gateway v2 and ALB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       attestations: write # build attestations
     strategy:
       matrix:
-        module: [apigateway, alb, lambdaurl]
+        module: [apigateway, apigatewayv2, alb, lambdaurl]
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        module: [apigateway, alb, lambdaurl, local]
+        module: [apigateway, apigatewayv2, alb, lambdaurl, local]
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,28 @@ builds:
       - amd64
       - arm64
 
+  - id: apigatewayv2
+    dir: .
+    main: ./cmd/apigatewayv2/main.go
+    binary: "bootstrap"
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -tags=lambda.norpc
+      - -trimpath
+    ldflags:
+      - -X github.com/boogy/aws-oidc-warden/internal/version.Version={{.Version}}
+      - -X github.com/boogy/aws-oidc-warden/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/boogy/aws-oidc-warden/internal/version.Date={{.Date}}
+      - -s -w
+      - -extldflags "-static"
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
   - id: alb
     dir: .
     main: ./cmd/alb/main.go
@@ -80,6 +102,15 @@ archives:
     name_template: "{{ .ProjectName }}_apigateway_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - src: dist/apigateway_{{ .Os }}_{{ .Arch }}*/bootstrap
+        dst: bootstrap
+
+  - id: apigatewayv2
+    ids:
+      - apigatewayv2
+    formats: ["zip"]
+    name_template: "{{ .ProjectName }}_apigatewayv2_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - src: dist/apigatewayv2_{{ .Os }}_{{ .Arch }}*/bootstrap
         dst: bootstrap
 
   - id: alb

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -29,6 +29,28 @@ builds:
       - latest
       - latest-apigateway
 
+  - id: apigatewayv2
+    dir: .
+    main: ./cmd/apigatewayv2/main.go
+    binary: bootstrap
+    env:
+      - CGO_ENABLED=0
+      - GOOS=linux
+    ldflags:
+      - -extldflags "-static"
+      - -s -w
+      - -X github.com/boogy/aws-oidc-warden/internal/version.Version={{.Git.Tag}}
+      - -X github.com/boogy/aws-oidc-warden/internal/version.Commit={{.Git.ShortCommit}}
+      - -X github.com/boogy/aws-oidc-warden/internal/version.Date={{.Date}}
+    flags:
+      - -tags=lambda.norpc
+      - -trimpath
+    tags:
+      - "{{.Git.Tag}}"
+      - "{{.Git.Tag}}-apigatewayv2"
+      - latest
+      - latest-apigatewayv2
+
   - id: alb
     dir: .
     main: ./cmd/alb/main.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ALB and API Gateway delegated modes now enforce token expiration (`exp` required) and reject future-`iat` tokens, matching self-mode strictness.
+- RSA JWKS keys shorter than 2048 bits are now rejected, and EC JWKS keys are validated to lie on their declared curve (defense-in-depth against a compromised JWKS source).
+- Malformed role ARNs now return the dedicated `ErrInvalidRoleFormat` sentinel (still HTTP 400) instead of being misreported as an empty role.
+- Frontend adapters (`alb`, `apigateway`, `lambdaurl`) now share the `classifyError` helper, removing duplicated/dead error-classification switches.
+- Invalid `LOG_LEVEL` now logs a well-formed structured warning instead of a malformed printf-style line; full claims log at Debug rather than Info.
 - JWT validation failures now return HTTP 401 instead of HTTP 500 (#230)
 - S3 config hot-reload no longer triggers N concurrent fetches at the interval boundary — exactly one fetch per interval (#230)
 - `AOW_*` env-var overrides are preserved across S3 hot-reloads (#230)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,182 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Breaking Changes
+
+- **S3/JSON config files must use `snake_case` keys** — `PascalCase` keys (`RepoRoleMappings`, `RoleSessionName`, etc.) are no longer accepted. Migrate any S3-hosted JSON configs to `snake_case` before upgrading (#230)
+- **`workflow_ref` constraint regex is now auto-anchored** — previously matched as a substring; now compiled as `^(?:...)$` like all other constraints. Patterns relying on partial matching must be updated (#237)
+
+### Added
+
+- Cross-account tag-based authorization (hub/spoke) — spoke accounts delegate role assumption decisions to a hub via ABAC session tags (#236)
+- Transitive session tags + target-account allow-list — session tags now flow across assumed roles; a per-repo `target_accounts` allow-list restricts which accounts a token may reach (#233)
+- Short `aow`/`repo` session tags via `tag_auth.default_org` — when a default org is set, the org prefix is stripped from session tag values to stay within the 256-char STS limit (#234)
+- EC key support restored (ES256/384/512) — EC tokens were incorrectly rejected in prior versions (#230)
+- Hot-reload now propagates to the AWS consumer — `allowed_accounts`, tag-auth enable/disable, spoke role, and external-id changes take effect without a Lambda cold start (#237)
+- Validator reads issuer/audiences from the live config on every call — revoked audiences are enforced immediately after an S3 config reload (#230)
+
+### Fixed
+
+- JWT validation failures now return HTTP 401 instead of HTTP 500 (#230)
+- S3 config hot-reload no longer triggers N concurrent fetches at the interval boundary — exactly one fetch per interval (#230)
+- `AOW_*` env-var overrides are preserved across S3 hot-reloads (#230)
+- S3Logger now initialises after the config provider so `log_bucket`/`log_prefix` from remote config are respected (#230)
+
+### Changed
+
+- Moved `pkg/` to `internal/` — all shared packages are now under `internal/` in line with Go conventions
+
+### Dependencies
+
+- actions/checkout 6.0.3 → 7.0.0
+- securego/gosec 2.26.1 → 2.27.1
+- codecov/codecov-action 6.0.1 → 7.0.0
+- github/codeql-action 4.36.0 → 4.36.2
+- docker/login-action 4.1.0 → 4.2.0
+- golangci/golangci-lint-action 9.2.0 → 9.2.1
+- goreleaser/goreleaser-action 7.2.1 → 7.2.2
+- aquasecurity/trivy-action 0.35.0 → 0.36.0
+- securego/gosec 2.25.0 → 2.26.1
+
+---
+
+## [1.3.6] - 2026-01-25
+
+### Changed
+
+- Updated dependencies and documentation (#125)
+
+### Dependencies
+
+- actions/setup-go 6.1.0 → 6.2.0
+- golangci/golangci-lint-action 9.1.0 → 9.2.0
+- github/codeql-action 4.31.4 → 4.31.11
+- actions/checkout 6.0.0 → 6.0.1
+- codecov/codecov-action 5.5.1 → 5.5.2
+- securego/gosec 2.22.10 → 2.22.11
+
+---
+
+## [1.3.5] - 2025-11-30
+
+### Dependencies
+
+- Updated Go dependencies (#109)
+- actions/setup-go 6.0.0 → 6.1.0
+- golangci/golangci-lint-action 8.0.0 → 9.1.0
+- github/codeql-action 4.31.2 → 4.31.4
+- actions/checkout 5.0.0 → 6.0.0
+
+---
+
+## [1.3.4] - 2025-11-06
+
+### Dependencies
+
+- Updated Go dependencies (#98)
+- github/codeql-action 3.30.5 → 4.31.2
+- docker/login-action 3.5.0 → 3.6.0
+
+---
+
+## [1.3.3] - 2025-09-19
+
+### Dependencies
+
+- Updated Go version and dependencies (#71)
+- actions/setup-go 5.5.0 → 6.0.0
+- aquasecurity/trivy-action 0.32.0 → 0.33.1
+- github/codeql-action 3.29.11 → 3.30.3
+
+---
+
+## [1.3.2] - 2025-08-29
+
+### Dependencies
+
+- Bumped golang module (#60)
+- github.com/aws/aws-sdk-go-v2/service/sts
+- actions/checkout 4.2.2 → 5.0.0
+- goreleaser/goreleaser-action 6.3.0 → 6.4.0
+
+---
+
+## [1.3.1] - 2025-08-18
+
+### Fixed
+
+- Replaced deprecated `builds` with `ids` in goreleaser archives (#25)
+- Fixed goreleaser configuration issues (#53)
+
+### Dependencies
+
+- Bumped golang modules (#53)
+- docker/login-action 3.4.0 → 3.5.0
+- aquasecurity/trivy-action 0.31.0 → 0.32.0
+- github/codeql-action 3.29.0 → 3.29.8
+
+---
+
+## [1.3.0] - 2025-07-14
+
+### Performance
+
+- Optimized Lambda bootstrap initialization — moved AWS client construction out of the hot path; Lambda cold starts reduced (#24)
+
+### Dependencies
+
+- github/codeql-action 3.28.19 → 3.29.0
+
+---
+
+## [1.2.0] - 2025-06-10
+
+### Added
+
+- Multi-audience support for OIDC token validation — `audience` config field now accepts a list; all values are checked against the token's `aud` claim (#6)
+- CodeQL security analysis workflow and badge
+
+### Changed
+
+- Improved example configuration with better security patterns
+- Updated GoReleaser archive format to modern syntax
+
+---
+
+## [1.1.0] - 2025-06-07
+
+### Added
+
+- `make build` command and improved CI workflow (#5)
+
+---
+
+## [1.0.0] - 2025-06-07
+
+### Added
+
+- Initial release — modular architecture with Lambda (API Gateway, ALB, Lambda URL) and local HTTP server deployment targets
+- OIDC JWT validation with JWKS signature verification
+- AWS STS AssumeRole with ABAC session tagging from token claims
+- Repository + constraint matching with anchored regex
+- Multi-tier JWKS cache (memory / DynamoDB / S3)
+- Container image published to GHCR and Docker Hub
+- CodeQL, Trivy, and gosec security scanning in CI
+
+[Unreleased]: https://github.com/boogy/aws-oidc-warden/compare/v1.3.6...HEAD
+[1.3.6]: https://github.com/boogy/aws-oidc-warden/compare/v1.3.5...v1.3.6
+[1.3.5]: https://github.com/boogy/aws-oidc-warden/compare/v1.3.4...v1.3.5
+[1.3.4]: https://github.com/boogy/aws-oidc-warden/compare/v1.3.3...v1.3.4
+[1.3.3]: https://github.com/boogy/aws-oidc-warden/compare/v1.3.2...v1.3.3
+[1.3.2]: https://github.com/boogy/aws-oidc-warden/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/boogy/aws-oidc-warden/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/boogy/aws-oidc-warden/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/boogy/aws-oidc-warden/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/boogy/aws-oidc-warden/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/boogy/aws-oidc-warden/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EC key support restored (ES256/384/512) — EC tokens were incorrectly rejected in prior versions (#230)
 - Hot-reload now propagates to the AWS consumer — `allowed_accounts`, tag-auth enable/disable, spoke role, and external-id changes take effect without a Lambda cold start (#237)
 - Validator reads issuer/audiences from the live config on every call — revoked audiences are enforced immediately after an S3 config reload (#230)
+- `jwt_validation.mode` config option (`"self"` / `"apigw"` / `"alb"`) to delegate JWT verification to API Gateway HTTP API v2 JWT Authorizer or ALB OIDC.
+- `ClaimsExtractorInterface` in `internal/validator/` with `SelfExtractor`, `APIGWExtractor`, and `ALBExtractor` implementations.
+- `AwsApiGatewayV2` Lambda adapter (`internal/handler/apigatewayv2.go`) and `cmd/apigatewayv2/` entry point for HTTP API v2 deployments.
+- `ParseRoleOnlyRequestBody` for delegated-mode requests (only `role` ARN required in body).
+- `AOW_JWT_VALIDATION_MODE` and `AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER` environment variables.
+- In-memory ALB public key cache (5-minute TTL) in `ALBExtractor` to avoid per-request HTTP latency.
 
 ### Fixed
 
@@ -31,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved `pkg/` to `internal/` — all shared packages are now under `internal/` in line with Go conventions
+- `ProcessRequest` signature now accepts `validator.ExtractionInput` to carry per-request extraction data.
+- `RequestProcessor` holds `ClaimsExtractorInterface` instead of `TokenValidatorInterface` directly.
 
 ### Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ This file is the map. Each package below has its own `CLAUDE.md` with the detail
 - Use interfaces for testability (`AwsConsumerInterface`, `TokenValidatorInterface`); table-driven tests.
 - Sentinel errors in `internal/handler/types.go`, mapped to HTTP status in the frontend adapters.
 - Config precedence: env vars > YAML > defaults.
+- Maintain a clean, up-to-date `CHANGELOG.md`.
 
 ## Security
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build-local:
 	@go build $(GO_BUILD_FLAGS) -o $(BUILD_DIR)/$(APP_NAME)-local ./cmd/local
 
 .PHONY: build-lambda
-build-lambda: build-apigateway build-alb build-lambdaurl
+build-lambda: build-apigateway build-apigatewayv2 build-alb build-lambdaurl
 
 .PHONY: build-all
 build-all: build-local build-lambda
@@ -44,6 +44,12 @@ build-apigateway:
 	@echo "Building API Gateway Lambda binary..."
 	@mkdir -p $(BUILD_DIR)
 	@GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GO_BUILD_FLAGS) -o $(BUILD_DIR)/bootstrap-apigateway ./cmd/apigateway
+
+.PHONY: build-apigatewayv2
+build-apigatewayv2:
+	@echo "Building API Gateway v2 Lambda binary..."
+	@mkdir -p $(BUILD_DIR)
+	@GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GO_BUILD_FLAGS) -o $(BUILD_DIR)/bootstrap-apigatewayv2 ./cmd/apigatewayv2
 
 .PHONY: build-alb
 build-alb:
@@ -144,12 +150,12 @@ test-coverage:
 .PHONY: ko-build
 ko-build: verify-ko
 	@echo "Building container images with ko locally..."
-	@KO_DOCKER_REPO=ko.local ko build ./cmd/apigateway ./cmd/alb ./cmd/lambdaurl --tags=$(VERSION),latest
+	@KO_DOCKER_REPO=ko.local ko build ./cmd/apigateway ./cmd/apigatewayv2 ./cmd/alb ./cmd/lambdaurl --tags=$(VERSION),latest
 
 .PHONY: ko-publish
 ko-publish: verify-ko
 	@echo "Publishing container images to $(KO_DOCKER_REPO)..."
-	@KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/apigateway ./cmd/alb ./cmd/lambdaurl --bare --tags=$(VERSION),latest
+	@KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/apigateway ./cmd/apigatewayv2 ./cmd/alb ./cmd/lambdaurl --bare --tags=$(VERSION),latest
 
 .PHONY: ko-publish-all
 ko-publish-all: ko-publish
@@ -196,6 +202,7 @@ help:
 	@echo "  make build-lambda         Build all Lambda binaries"
 	@echo "  make build-all            Build all binaries (local + lambda)"
 	@echo "  make build-apigateway     Build API Gateway Lambda binary"
+	@echo "  make build-apigatewayv2   Build API Gateway v2 Lambda binary"
 	@echo "  make build-alb            Build ALB Lambda binary"
 	@echo "  make build-lambdaurl      Build Lambda URL binary"
 	@echo "  make run                  Run local development server"

--- a/cmd/apigatewayv2/main.go
+++ b/cmd/apigatewayv2/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/boogy/aws-oidc-warden/internal/handler"
+)
+
+var bootstrap *handler.Bootstrap
+
+func init() {
+	var err error
+	bootstrap, err = handler.NewBootstrap()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	defer bootstrap.Cleanup()
+	h := handler.NewAwsApiGatewayV2FromBootstrap(bootstrap)
+	lambda.Start(h.Handler)
+}

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -56,14 +56,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Initialize the token validator
-	validator := validator.NewTokenValidator(cfg, jwksCache)
+	// Initialize the token validator and wrap it in a SelfExtractor so the local
+	// server always validates JWT signatures itself (no delegated mode).
+	tokenValidator := validator.NewTokenValidator(cfg, jwksCache)
+	extractor := validator.NewSelfExtractor(tokenValidator)
 
 	// Initialize the AWS client
 	awsClient := aws.NewAwsConsumer(cfg)
 
 	// Create the handler function (static config provider — no hot-reload locally)
-	handlerFunc := handler.NewAwsApiGateway(config.NewStaticProvider(cfg), awsClient, validator).Handler
+	handlerFunc := handler.NewAwsApiGateway(config.NewStaticProvider(cfg), awsClient, extractor).Handler
 
 	// Set up HTTP server
 	http.HandleFunc("/verify", func(w http.ResponseWriter, r *http.Request) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,27 +73,33 @@ GitHub Actions → API Gateway → AWS OIDC Warden (Lambda Function Proxy)
 - **Entry Point**: `cmd/apigateway/main.go`
 
 #### Lambda URLs
+
 ```
 GitHub Actions → AWS OIDC Warden (Lambda Function URL)
 ```
+
 - **Use Case**: Simplified setup for direct Lambda invocation
 - **Benefits**: Lower latency, reduced cost, simpler configuration
 - **Handler**: `internal/handler/lambdaurl.go`
 - **Entry Point**: `cmd/lambdaurl/main.go`
 
 #### Application Load Balancer
+
 ```
 GitHub Actions → ALB → AWS OIDC Warden (Lambda Function)
 ```
+
 - **Use Case**: High-traffic scenarios with advanced routing
 - **Benefits**: Multi-region support, advanced health checks, WAF integration
 - **Handler**: `internal/handler/alb.go`
 - **Entry Point**: `cmd/alb/main.go`
 
 #### Local Development Server
+
 ```
 GitHub Actions → HTTP Server → AWS OIDC Warden
 ```
+
 - **Use Case**: Local development and testing
 - **Benefits**: Fast iteration, debugging capabilities, local testing
 - **Handler**: Built into local server
@@ -186,6 +192,7 @@ type RequestProcessor interface {
 ```
 
 **Key Responsibilities:**
+
 - HTTP request parsing and validation
 - Response formatting and error handling
 - Request ID generation and correlation
@@ -193,6 +200,7 @@ type RequestProcessor interface {
 - Context management and timeouts
 
 **Files:**
+
 - `bootstrap.go` - Common initialization logic
 - `processor.go` - Core business logic
 - `types.go` - Request/response data structures
@@ -212,6 +220,7 @@ type TokenValidatorInterface interface {
 ```
 
 **Validation Process:**
+
 1. **JWT Parsing**: Decode and parse the JWT token
 2. **JWKS Retrieval**: Fetch public keys from OIDC provider (with caching); forced refresh on key-miss (rotation recovery)
 3. **Signature Verification**: Verify token signature using RSA (`RS256`/`RS384`/`RS512`) or ECDSA (`ES256`/`ES384`/`ES512`) public keys; `GenKeyFunc` switches on the JWKS key `kty` field (`RSA` → `parseRSAKey`, `EC` → `parseECKey`)
@@ -219,6 +228,7 @@ type TokenValidatorInterface interface {
 5. **Provider-Aware**: Created via `NewTokenValidatorFromProvider`; reads issuer/audiences live from the provider on every `Validate()` call so hot-reloaded config changes take effect immediately without a restart
 
 **Security Features:**
+
 - Allowed algorithms enforced: ES256/384/512, RS256/384/512 — `none` and all other algorithms rejected
 - Issuer and multi-audience validation (any expected audience match accepted)
 - Token expiration and `iat` required
@@ -239,6 +249,7 @@ type AwsConsumerInterface interface {
 ```
 
 **AWS Operations:**
+
 - **Role Assumption**: Use AWS STS to assume target IAM roles
 - **Session Tagging**: Apply GitHub-specific tags to AWS sessions
 - **Session Policies**: Apply custom IAM policies to limit permissions
@@ -246,6 +257,7 @@ type AwsConsumerInterface interface {
 - **IAM Integration**: Validate role existence and trust relationships
 
 **Session Tags Applied:**
+
 ```go
 tags := []types.Tag{
     {Key: aws.String("repo"), Value: aws.String(claims.Repository)},
@@ -271,18 +283,21 @@ type Cache interface {
 ```
 
 #### Memory Cache
+
 - **Implementation**: LRU-based in-memory cache
 - **Use Case**: Low-latency access for frequently accessed JWKS
 - **Limitations**: Lost on Lambda container recycling
 - **Configuration**: Maximum size and TTL configurable
 
 #### DynamoDB Cache
+
 - **Implementation**: AWS DynamoDB with automatic TTL
 - **Use Case**: Persistent cache shared across Lambda instances
 - **Benefits**: High availability, automatic scaling, built-in TTL
 - **Configuration**: Table name and TTL configurable
 
 #### S3 Cache
+
 - **Implementation**: S3 objects with metadata-based TTL
 - **Use Case**: Large objects and long-term caching
 - **Benefits**: Cost-effective, unlimited storage, optional cleanup
@@ -305,6 +320,7 @@ type Config struct {
 ```
 
 **Configuration Sources** (in order of precedence):
+
 1. Environment variables (with `AOW_` prefix)
 2. Configuration file (YAML/JSON/TOML)
 3. S3-stored configuration
@@ -322,16 +338,17 @@ type Config struct {
 The token validator is constructed via `NewTokenValidatorFromProvider`, which reads issuer and audiences from `provider.Get()` on every `Validate()` call so hot-reloaded issuer/audience changes take effect immediately without a Lambda restart.
 
 **Repository Mapping System:**
+
 ```yaml
 repo_role_mappings:
-  - repo: "org/project-.*"              # Regex pattern matching
+  - repo: "org/project-.*" # Regex pattern matching
     roles:
       - "arn:aws:iam::123456789012:role/github-actions-role"
     constraints:
-      branch: "refs/heads/main"         # Branch constraints
-      actor_matches: ["admin-.*"]      # Actor constraints
-      event_name: "push"               # Event type constraints
-    session_policy: |                  # Inline session policy
+      branch: "refs/heads/main" # Branch constraints
+      actor_matches: ["admin-.*"] # Actor constraints
+      event_name: "push" # Event type constraints
+    session_policy: | # Inline session policy
       {
         "Version": "2012-10-17",
         "Statement": [...]
@@ -387,6 +404,7 @@ type Constraint struct {
 ```
 
 **Validation Logic:**
+
 - All specified constraints must be satisfied (AND logic)
 - Regular expressions supported for pattern matching
 - Claims are extracted from the validated JWT token
@@ -410,6 +428,7 @@ flowchart LR
 ```
 
 **Cache TTL Strategy:**
+
 - **Memory Cache**: Short TTL (minutes to hours) for hot data
 - **DynamoDB Cache**: Medium TTL (hours) for persistence
 - **S3 Cache**: Long TTL (days) for cold data
@@ -457,12 +476,14 @@ flowchart TD
 ### 3. AWS Integration Security
 
 **Role Assumption:**
+
 - Uses AWS STS AssumeRole with session tags
 - Applies custom session policies for additional restrictions
 - Validates role trust relationships
 - Implements principle of least privilege
 
 **Session Security:**
+
 - Session duration limits (default: 1 hour, max: 12 hours)
 - Session tags for audit trails and ABAC policies
 - Optional session policies to further restrict permissions
@@ -473,6 +494,7 @@ flowchart TD
 Tag-based authorization is opt-in (`tag_auth.enabled`, default `false`) and is a fallback after explicit `repo_role_mappings` matching fails. See [TAG_BASED_AUTHORIZATION.md](TAG_BASED_AUTHORIZATION.md) for the full tag reference and IAM setup.
 
 **Hub/Spoke Flow:**
+
 1. The hub (warden's own AWS account) is the central trust anchor.
 2. For each requested role ARN the account ID is parsed from the ARN.
 3. If the target is a different account, the warden assumes a convention-named spoke role (`arn:aws:iam::<account>:role/<SpokeRoleName>`, default `aow-spoke`) using `sts:AssumeRole` with an optional `ExternalID`. The spoke session is short-lived (`SpokeSessionDuration`, default 15 min) and the credentials are cached in-process per account.
@@ -488,27 +510,29 @@ When `tag_auth.default_org` is set, bare repo names in `aow/repo` tag values (no
 
 **Diagrams:**
 
-| Diagram | File |
-|---------|------|
-| Authorization decision flow | [images/tag-auth-decision.svg](images/tag-auth-decision.svg) |
-| Cross-account hub/spoke flow | [images/tag-auth-crossaccount.svg](images/tag-auth-crossaccount.svg) |
-| ABAC session tag flow | [images/tag-auth-abac.svg](images/tag-auth-abac.svg) |
-| Transitive session tags | [images/tag-auth-transitive.svg](images/tag-auth-transitive.svg) |
-| Account allow-list enforcement | [images/tag-auth-accounts.svg](images/tag-auth-accounts.svg) |
-| Tag matching logic | [images/tag-auth-matching.svg](images/tag-auth-matching.svg) |
-| Authorization precedence | [images/tag-auth-precedence.svg](images/tag-auth-precedence.svg) |
+| Diagram                        | File                                                                 |
+| ------------------------------ | -------------------------------------------------------------------- |
+| Authorization decision flow    | [images/tag-auth-decision.svg](images/tag-auth-decision.svg)         |
+| Cross-account hub/spoke flow   | [images/tag-auth-crossaccount.svg](images/tag-auth-crossaccount.svg) |
+| ABAC session tag flow          | [images/tag-auth-abac.svg](images/tag-auth-abac.svg)                 |
+| Transitive session tags        | [images/tag-auth-transitive.svg](images/tag-auth-transitive.svg)     |
+| Account allow-list enforcement | [images/tag-auth-accounts.svg](images/tag-auth-accounts.svg)         |
+| Tag matching logic             | [images/tag-auth-matching.svg](images/tag-auth-matching.svg)         |
+| Authorization precedence       | [images/tag-auth-precedence.svg](images/tag-auth-precedence.svg)     |
 
 ## Performance Architecture
 
 ### 1. Caching Performance
 
 **Cache Hit Rates:**
+
 - Memory Cache: >95% for active repositories
 - DynamoDB Cache: >85% for warm data
 - S3 Cache: >70% for cold data
 - Overall System: >98% cache hit rate
 
 **Performance Metrics:**
+
 - Memory Cache Lookup: <1ms
 - DynamoDB Cache Lookup: <10ms
 - S3 Cache Lookup: <50ms
@@ -517,12 +541,14 @@ When `tag_auth.default_org` is set, bare repo names in `aow/repo` tag values (no
 ### 2. Lambda Performance Optimizations
 
 **Cold Start Mitigation:**
+
 - Minimal dependencies and imports
 - Connection pooling for AWS services
 - Lazy initialization of non-critical components
 - Provisioned concurrency for high-traffic scenarios
 
 **Memory and CPU Optimization:**
+
 - Configurable Lambda memory allocation
 - ARM64 support for better price/performance
 - Efficient JWT parsing and validation
@@ -556,6 +582,7 @@ graph LR
 ```
 
 **Scaling Strategies:**
+
 - **Lambda Auto-scaling**: Automatic scaling based on incoming requests
 - **DynamoDB On-Demand**: Pay-per-request with automatic scaling
 - **S3 Unlimited Scale**: No capacity planning required
@@ -579,6 +606,7 @@ CMD ["bootstrap"]
 ```
 
 **Container Registry Options:**
+
 - GitHub Container Registry (GHCR): `ghcr.io/boogy/aws-oidc-warden`
 - Docker Hub: `boogy/aws-oidc-warden`
 - AWS ECR: Private registry with pull-through cache
@@ -586,6 +614,7 @@ CMD ["bootstrap"]
 ### 2. Infrastructure as Code
 
 **Terraform Example:**
+
 ```hcl
 resource "aws_lambda_function" "aws_oidc_warden" {
   function_name = "aws-oidc-warden"
@@ -610,11 +639,43 @@ The Lambda execution role requires the following IAM permissions:
 {
   "Version": "2012-10-17",
   "Statement": [
-    { "Effect": "Allow", "Action": ["sts:AssumeRole", "sts:TagSession"], "Resource": ["arn:aws:iam::*:role/github-actions-*"] },
-    { "Effect": "Allow", "Action": ["iam:GetRole"], "Resource": ["arn:aws:iam::*:role/*"] },
-    { "Effect": "Allow", "Action": ["dynamodb:GetItem","dynamodb:PutItem","dynamodb:UpdateItem","dynamodb:DeleteItem"], "Resource": ["arn:aws:dynamodb:*:*:table/aws-oidc-warden-cache"] },
-    { "Effect": "Allow", "Action": ["s3:GetObject","s3:PutObject"], "Resource": ["arn:aws:s3:::s3-aws-oidc-warden-session-policies/*"] },
-    { "Effect": "Allow", "Action": ["logs:CreateLogGroup","logs:CreateLogStream","logs:PutLogEvents"], "Resource": ["arn:aws:logs:*:*:log-group:*","arn:aws:logs:*:*:log-group:*:log-stream:*"] }
+    {
+      "Effect": "Allow",
+      "Action": ["sts:AssumeRole", "sts:TagSession"],
+      "Resource": ["arn:aws:iam::*:role/github-actions-*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["iam:GetRole"],
+      "Resource": ["arn:aws:iam::*:role/*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem"
+      ],
+      "Resource": ["arn:aws:dynamodb:*:*:table/aws-oidc-warden-cache"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": ["arn:aws:s3:::s3-aws-oidc-warden-session-policies/*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:log-group:*",
+        "arn:aws:logs:*:*:log-group:*:log-stream:*"
+      ]
+    }
   ]
 }
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,6 +155,24 @@ sequenceDiagram
     Handler-->>Client: HTTP 200 + credentials
 ```
 
+## JWT Validation Modes
+
+Three modes controlled by `jwt_validation.mode`:
+
+| Mode    | Verifier              | Claims source                                | Binary         |
+| ------- | --------------------- | -------------------------------------------- | -------------- |
+| `self`  | This service (JWKS)   | JWT body after full verification             | any            |
+| `apigw` | API Gateway (managed) | `event.requestContext.authorizer.jwt.claims` | `apigatewayv2` |
+| `alb`   | This service (ES256)  | `x-amzn-oidc-data` after ALB key verify      | `alb`          |
+
+**Security invariant:** In delegated modes, if no upstream-injected claims arrive (direct Lambda invocation bypass), `Extract()` returns an error wrapping `ErrTokenValidationFailed` → HTTP 401.
+
+**API Gateway mode** requires an `aws_apigatewayv2_authorizer` JWT resource pointing at `https://token.actions.githubusercontent.com`. Restrict Lambda invocations to the API Gateway execution role via Lambda resource-based policies.
+
+**ALB mode** verifies the ALB-signed ES256 JWT but does not re-verify the original OIDC signature. Set `alb_expected_signer` to the ALB ARN to prevent cross-ALB token injection.
+
+**Hot-reload note:** The extractor implementation is fixed at Lambda cold start. Changing `jwt_validation.mode` requires a redeployment.
+
 ## Core Components Deep Dive
 
 ### Request Handler (`internal/handler/`)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -65,6 +65,13 @@ Optional, disabled by default. When enabled, a repo may assume a role whose IAM 
 | `AOW_LOG_PREFIX`     | `log_prefix`    | S3 key prefix for logs                   |         |
 | `LOG_LEVEL`          | N/A             | Logging level (debug, info, warn, error) | `info`  |
 
+### JWT Validation Mode Settings
+
+| Environment Variable | Config File Key | Description | Default |
+| -------------------- | --------------- | ----------- | ------- |
+| `AOW_JWT_VALIDATION_MODE` | `jwt_validation.mode` | JWT validation mode (`"self"`, `"apigw"`, or `"alb"`) | `"self"` |
+| `AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER` | `jwt_validation.alb_expected_signer` | ARN of the trusted ALB (ALB mode only, recommended) | (empty) |
+
 ### Other Settings
 
 | Environment Variable | Default Value                                        | Description                          | Default  |
@@ -150,6 +157,150 @@ const apiToken = await core.getIDToken("https://api.mycompany.com");
 ```
 
 The AWS OIDC Warden will validate tokens against any of the configured audiences. If the token's audience matches any of the expected audiences, validation succeeds.
+
+## JWT Validation Mode
+
+AWS OIDC Warden supports three JWT validation modes, selectable via the `jwt_validation.mode` configuration option:
+
+### 1. Self Mode (Default)
+
+**Mode**: `"self"`
+
+This is the default and most straightforward mode. The service performs full JWT signature verification locally using JWKS keys fetched from the OIDC provider.
+
+**When to use:**
+- No trusted upstream service pre-validates tokens
+- Full control over validation logic
+- Direct Lambda URL or Lambda function invocations
+
+**Request format:**
+```bash
+curl -X POST https://lambda-url.example.com \
+  -H "Content-Type: application/json" \
+  -d '{
+    "token": "<full-github-actions-oidc-jwt>",
+    "role": "arn:aws:iam::123456789012:role/MyRole"
+  }'
+```
+
+**Configuration:**
+```yaml
+jwt_validation:
+  mode: "self"
+```
+
+### 2. API Gateway HTTP API v2 Mode
+
+**Mode**: `"apigw"`
+
+Trust pre-validated JWT claims from API Gateway HTTP API v2 JWT Authorizer. The Lambda function receives authorizer-validated claims in the request context and skips re-validation.
+
+**When to use:**
+- API Gateway HTTP API v2 JWT Authorizer is configured upstream
+- Avoiding duplicate JWT validation (API Gateway already verifies)
+- Delegating signature verification to API Gateway
+
+**Setup steps:**
+
+1. **Create API Gateway JWT Authorizer:**
+   - Issuer URL: `https://token.actions.githubusercontent.com`
+   - Audience: One of the values in `audiences` config (e.g., `sts.amazonaws.com`)
+   - Token source: `Authorization` header
+
+2. **Deploy using API Gateway v2 binary:**
+   ```bash
+   make build-apigatewayv2
+   # Deploy build/bootstrap-apigatewayv2 as Lambda function
+   ```
+
+3. **Restrict Lambda invocations:**
+   Add a Lambda resource-based policy to allow only API Gateway execution role:
+   ```json
+   {
+     "Effect": "Allow",
+     "Principal": {
+       "Service": "apigateway.amazonaws.com"
+     },
+     "Action": "lambda:InvokeFunction",
+     "Resource": "arn:aws:lambda:region:account:function:function-name"
+   }
+   ```
+
+4. **Configure the service:**
+   ```yaml
+   jwt_validation:
+     mode: "apigw"
+   ```
+
+**Request format:**
+When using API Gateway, the client sends the token in the `Authorization` header and only the role in the request body:
+```bash
+curl -X POST https://api.example.com/assume-role \
+  -H "Authorization: Bearer <github-actions-oidc-jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"role": "arn:aws:iam::123456789012:role/MyRole"}'
+```
+
+**Security notes:**
+- API Gateway validates the JWT signature before invoking Lambda
+- Lambda must restrict invocations to API Gateway via resource-based policy (prevent direct invocation bypass)
+- No token re-validation by Lambda; trust API Gateway's validation
+
+### 3. ALB OIDC Mode
+
+**Mode**: `"alb"`
+
+Trust ALB OIDC authentication. The ALB signs OIDC tokens with ES256 and passes them in the `x-amzn-oidc-data` header. This service verifies the signature using the ALB's EC public key.
+
+**When to use:**
+- ALB is configured with GitHub OIDC as the identity provider
+- Load balancer handles OIDC flow and token generation
+- Need to validate ALB-signed tokens
+
+**ALB Setup:**
+
+1. **Configure ALB with GitHub OIDC:**
+   - OIDC provider endpoint: `https://token.actions.githubusercontent.com`
+   - Client ID: Use `sts.amazonaws.com` as the audience
+   - Set ALB listener rule to authenticate via OIDC
+
+2. **Deploy using ALB binary:**
+   ```bash
+   make build-alb
+   # Deploy build/bootstrap-alb as Lambda function behind ALB
+   ```
+
+3. **Configure the service:**
+   ```yaml
+   jwt_validation:
+     mode: "alb"
+     alb_expected_signer: "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc"
+   ```
+
+**Request format:**
+ALB automatically injects the `x-amzn-oidc-data` header; clients send only the role:
+```bash
+# Client sends to ALB (no token needed in request)
+curl -X POST https://alb.example.com/assume-role \
+  -H "Content-Type: application/json" \
+  -d '{"role": "arn:aws:iam::123456789012:role/MyRole"}'
+
+# ALB intercepts, authenticates with GitHub OIDC, and injects x-amzn-oidc-data
+# Lambda receives the OIDC token in the header
+```
+
+**Security notes:**
+- ALB performs GitHub OIDC authentication and token generation
+- Lambda verifies ALB-signed ES256 JWT from `x-amzn-oidc-data` header
+- Set `alb_expected_signer` (ALB ARN) to prevent cross-ALB token injection
+- `AWS_REGION` environment variable must be set (used for ALB public key lookup)
+
+**Environment variables:**
+```bash
+export AWS_REGION=us-east-1
+export AOW_JWT_VALIDATION_MODE=alb
+export AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER="arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc"
+```
 
 ## Configuration File Format
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -70,7 +70,7 @@ Optional, disabled by default. When enabled, a repo may assume a role whose IAM 
 | Environment Variable | Config File Key | Description | Default |
 | -------------------- | --------------- | ----------- | ------- |
 | `AOW_JWT_VALIDATION_MODE` | `jwt_validation.mode` | JWT validation mode (`"self"`, `"apigw"`, or `"alb"`) | `"self"` |
-| `AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER` | `jwt_validation.alb_expected_signer` | ARN of the trusted ALB (ALB mode only, recommended) | (empty) |
+| `AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER` | `jwt_validation.alb_expected_signer` | ARN of the trusted ALB; **required** in ALB mode to prevent cross-ALB token injection | (empty, startup fails if unset in alb mode) |
 
 ### Other Settings
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,16 +14,16 @@ AWS OIDC Warden can be configured using:
 
 ### Core Settings
 
-| Environment Variable        | Config File Key         | Description                                 | Default                                       |
-| --------------------------- | ----------------------- | ------------------------------------------- | --------------------------------------------- |
-| `AOW_ISSUER`                | `issuer`                | OIDC issuer URL                             | `https://token.actions.githubusercontent.com` |
-| `AOW_AUDIENCE`              | `audience`              | Expected audience for tokens (legacy)       | `sts.amazonaws.com`                           |
-| `AOW_AUDIENCES`             | `audiences`             | Expected audiences for tokens (recommended) | `["sts.amazonaws.com"]`                       |
-| `AOW_ROLE_SESSION_NAME`     | `role_session_name`     | AWS role session name                       | `aws-oidc-warden`                             |
-| `AOW_S3_CONFIG_BUCKET`      | `s3_config_bucket`      | S3 bucket for config file                   |                                               |
-| `AOW_S3_CONFIG_PATH`        | `s3_config_path`        | Path to config file in S3                   |                                               |
-| `AOW_CONFIG_RELOAD_INTERVAL`| `config_reload_interval`| Hot-reload the S3 config at most this often (e.g. `5m`); `0` disables | `0` (disabled)                   |
-| `AOW_SESSION_POLICY_BUCKET` | `session_policy_bucket` | S3 bucket for session policies              |                                               |
+| Environment Variable         | Config File Key          | Description                                                           | Default                                       |
+| ---------------------------- | ------------------------ | --------------------------------------------------------------------- | --------------------------------------------- |
+| `AOW_ISSUER`                 | `issuer`                 | OIDC issuer URL                                                       | `https://token.actions.githubusercontent.com` |
+| `AOW_AUDIENCE`               | `audience`               | Expected audience for tokens (legacy)                                 | `sts.amazonaws.com`                           |
+| `AOW_AUDIENCES`              | `audiences`              | Expected audiences for tokens (recommended)                           | `["sts.amazonaws.com"]`                       |
+| `AOW_ROLE_SESSION_NAME`      | `role_session_name`      | AWS role session name                                                 | `aws-oidc-warden`                             |
+| `AOW_S3_CONFIG_BUCKET`       | `s3_config_bucket`       | S3 bucket for config file                                             |                                               |
+| `AOW_S3_CONFIG_PATH`         | `s3_config_path`         | Path to config file in S3                                             |                                               |
+| `AOW_CONFIG_RELOAD_INTERVAL` | `config_reload_interval` | Hot-reload the S3 config at most this often (e.g. `5m`); `0` disables | `0` (disabled)                                |
+| `AOW_SESSION_POLICY_BUCKET`  | `session_policy_bucket`  | S3 bucket for session policies                                        |                                               |
 
 > **Note**: You can use either `audience` (single) or `audiences` (multiple). If both are specified, `audiences` takes precedence. For new deployments, use `audiences` for better flexibility.
 
@@ -45,16 +45,16 @@ AWS OIDC Warden can be configured using:
 
 Optional, disabled by default. When enabled, a repo may assume a role whose IAM tags authorize its OIDC claims, even if the role is not listed in `repo_role_mappings`. Roles in other accounts are reached via a per-account spoke role. See [TAG_BASED_AUTHORIZATION.md](TAG_BASED_AUTHORIZATION.md) for the tag reference and IAM setup.
 
-| Environment Variable                  | Config File Key                  | Description                                              | Default     |
-| ------------------------------------- | -------------------------------- | ------------------------------------------------------- | ----------- |
-| `AOW_TAG_AUTH_ENABLED`                | `tag_auth.enabled`               | Enable tag-based authorization + cross-account assume   | `false`     |
-| `AOW_TAG_AUTH_TAG_PREFIX`             | `tag_auth.tag_prefix`            | Namespace prefix for authorization tag keys             | `aow/`      |
-| `AOW_TAG_AUTH_DEFAULT_ORG`            | `tag_auth.default_org`           | Org prefix for bare `aow/repo` tokens (e.g. `"api"` → `"<org>/api"`); empty = no expansion | (empty) |
-| `AOW_TAG_AUTH_SPOKE_ROLE_NAME`        | `tag_auth.spoke_role_name`       | Role assumed in each member account for cross-account   | `aow-spoke` |
-| `AOW_TAG_AUTH_EXTERNAL_ID`            | `tag_auth.external_id`           | Optional external ID for the hub→spoke trust            |             |
-| `AOW_TAG_AUTH_SPOKE_SESSION_DURATION` | `tag_auth.spoke_session_duration`| Hub→spoke session length                                | `15m`       |
-| `AOW_TAG_AUTH_TRANSITIVE_SESSION_TAGS` | `tag_auth.transitive_session_tags` | Mark repo/ref/actor session tags transitive (immutable through role chaining) | `false` |
-| `AOW_TAG_AUTH_ALLOWED_ACCOUNTS`        | `tag_auth.allowed_accounts`        | Comma-separated member account IDs allowed as assume targets (hub always allowed; empty = any) | (empty) |
+| Environment Variable                   | Config File Key                    | Description                                                                                    | Default     |
+| -------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------- | ----------- |
+| `AOW_TAG_AUTH_ENABLED`                 | `tag_auth.enabled`                 | Enable tag-based authorization + cross-account assume                                          | `false`     |
+| `AOW_TAG_AUTH_TAG_PREFIX`              | `tag_auth.tag_prefix`              | Namespace prefix for authorization tag keys                                                    | `aow/`      |
+| `AOW_TAG_AUTH_DEFAULT_ORG`             | `tag_auth.default_org`             | Org prefix for bare `aow/repo` tokens (e.g. `"api"` → `"<org>/api"`); empty = no expansion     | (empty)     |
+| `AOW_TAG_AUTH_SPOKE_ROLE_NAME`         | `tag_auth.spoke_role_name`         | Role assumed in each member account for cross-account                                          | `aow-spoke` |
+| `AOW_TAG_AUTH_EXTERNAL_ID`             | `tag_auth.external_id`             | Optional external ID for the hub→spoke trust                                                   |             |
+| `AOW_TAG_AUTH_SPOKE_SESSION_DURATION`  | `tag_auth.spoke_session_duration`  | Hub→spoke session length                                                                       | `15m`       |
+| `AOW_TAG_AUTH_TRANSITIVE_SESSION_TAGS` | `tag_auth.transitive_session_tags` | Mark repo/ref/actor session tags transitive (immutable through role chaining)                  | `false`     |
+| `AOW_TAG_AUTH_ALLOWED_ACCOUNTS`        | `tag_auth.allowed_accounts`        | Comma-separated member account IDs allowed as assume targets (hub always allowed; empty = any) | (empty)     |
 
 ### Logging Settings
 
@@ -67,9 +67,9 @@ Optional, disabled by default. When enabled, a repo may assume a role whose IAM 
 
 ### JWT Validation Mode Settings
 
-| Environment Variable | Config File Key | Description | Default |
-| -------------------- | --------------- | ----------- | ------- |
-| `AOW_JWT_VALIDATION_MODE` | `jwt_validation.mode` | JWT validation mode (`"self"`, `"apigw"`, or `"alb"`) | `"self"` |
+| Environment Variable                     | Config File Key                      | Description                                                                           | Default                                     |
+| ---------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `AOW_JWT_VALIDATION_MODE`                | `jwt_validation.mode`                | JWT validation mode (`"self"`, `"apigw"`, or `"alb"`)                                 | `"self"`                                    |
 | `AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER` | `jwt_validation.alb_expected_signer` | ARN of the trusted ALB; **required** in ALB mode to prevent cross-ALB token injection | (empty, startup fails if unset in alb mode) |
 
 ### Other Settings
@@ -169,11 +169,13 @@ AWS OIDC Warden supports three JWT validation modes, selectable via the `jwt_val
 This is the default and most straightforward mode. The service performs full JWT signature verification locally using JWKS keys fetched from the OIDC provider.
 
 **When to use:**
+
 - No trusted upstream service pre-validates tokens
 - Full control over validation logic
 - Direct Lambda URL or Lambda function invocations
 
 **Request format:**
+
 ```bash
 curl -X POST https://lambda-url.example.com \
   -H "Content-Type: application/json" \
@@ -184,6 +186,7 @@ curl -X POST https://lambda-url.example.com \
 ```
 
 **Configuration:**
+
 ```yaml
 jwt_validation:
   mode: "self"
@@ -196,6 +199,7 @@ jwt_validation:
 Trust pre-validated JWT claims from API Gateway HTTP API v2 JWT Authorizer. The Lambda function receives authorizer-validated claims in the request context and skips re-validation.
 
 **When to use:**
+
 - API Gateway HTTP API v2 JWT Authorizer is configured upstream
 - Avoiding duplicate JWT validation (API Gateway already verifies)
 - Delegating signature verification to API Gateway
@@ -208,6 +212,7 @@ Trust pre-validated JWT claims from API Gateway HTTP API v2 JWT Authorizer. The 
    - Token source: `Authorization` header
 
 2. **Deploy using API Gateway v2 binary:**
+
    ```bash
    make build-apigatewayv2
    # Deploy build/bootstrap-apigatewayv2 as Lambda function
@@ -215,6 +220,7 @@ Trust pre-validated JWT claims from API Gateway HTTP API v2 JWT Authorizer. The 
 
 3. **Restrict Lambda invocations:**
    Add a Lambda resource-based policy to allow only API Gateway execution role:
+
    ```json
    {
      "Effect": "Allow",
@@ -234,6 +240,7 @@ Trust pre-validated JWT claims from API Gateway HTTP API v2 JWT Authorizer. The 
 
 **Request format:**
 When using API Gateway, the client sends the token in the `Authorization` header and only the role in the request body:
+
 ```bash
 curl -X POST https://api.example.com/assume-role \
   -H "Authorization: Bearer <github-actions-oidc-jwt>" \
@@ -242,6 +249,7 @@ curl -X POST https://api.example.com/assume-role \
 ```
 
 **Security notes:**
+
 - API Gateway validates the JWT signature before invoking Lambda
 - Lambda must restrict invocations to API Gateway via resource-based policy (prevent direct invocation bypass)
 - No token re-validation by Lambda; trust API Gateway's validation
@@ -253,6 +261,7 @@ curl -X POST https://api.example.com/assume-role \
 Trust ALB OIDC authentication. The ALB signs OIDC tokens with ES256 and passes them in the `x-amzn-oidc-data` header. This service verifies the signature using the ALB's EC public key.
 
 **When to use:**
+
 - ALB is configured with GitHub OIDC as the identity provider
 - Load balancer handles OIDC flow and token generation
 - Need to validate ALB-signed tokens
@@ -265,6 +274,7 @@ Trust ALB OIDC authentication. The ALB signs OIDC tokens with ES256 and passes t
    - Set ALB listener rule to authenticate via OIDC
 
 2. **Deploy using ALB binary:**
+
    ```bash
    make build-alb
    # Deploy build/bootstrap-alb as Lambda function behind ALB
@@ -279,6 +289,7 @@ Trust ALB OIDC authentication. The ALB signs OIDC tokens with ES256 and passes t
 
 **Request format:**
 ALB automatically injects the `x-amzn-oidc-data` header; clients send only the role:
+
 ```bash
 # Client sends to ALB (no token needed in request)
 curl -X POST https://alb.example.com/assume-role \
@@ -290,12 +301,14 @@ curl -X POST https://alb.example.com/assume-role \
 ```
 
 **Security notes:**
+
 - ALB performs GitHub OIDC authentication and token generation
 - Lambda verifies ALB-signed ES256 JWT from `x-amzn-oidc-data` header
 - Set `alb_expected_signer` (ALB ARN) to prevent cross-ALB token injection
 - `AWS_REGION` environment variable must be set (used for ALB public key lookup)
 
 **Environment variables:**
+
 ```bash
 export AWS_REGION=us-east-1
 export AOW_JWT_VALIDATION_MODE=alb

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -334,27 +334,6 @@ repo_role_mappings:
       - arn:aws:iam::123456789012:role/github-actions-default-fallback
     # No constraints means this applies to all branches/events
 
-# JWT Validation Mode
-# Controls who validates the JWT signature.
-#
-# "self"  (default) - Full signature verification by this service using JWKS.
-#                     Required when no trusted upstream service pre-validates tokens.
-#
-# "apigw" - Trust API Gateway HTTP API v2 JWT Authorizer. Claims are read from
-#           event.requestContext.authorizer.jwt.claims. No re-validation by Lambda.
-#           Use with cmd/apigatewayv2/ binary. Configure API GW JWT Authorizer with
-#           issuerUrl: https://token.actions.githubusercontent.com and the expected audience.
-#           SECURITY: Restrict Lambda invocations to the API Gateway resource via
-#           Lambda resource-based policies to prevent direct invocation bypass.
-#
-# "alb"   - Trust ALB OIDC authentication. The x-amzn-oidc-data header JWT
-#           (ALB-signed with ES256) is verified. Suitable when ALB is configured
-#           with GitHub OIDC as identity provider.
-#           alb_expected_signer should be set to the ALB ARN to prevent spoofing.
-jwt_validation:
-  mode: "self"
-  # alb_expected_signer: "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc"
-
 # Tag-based authorization (optional, default disabled).
 # When enabled, a repo may assume a role whose IAM tags authorize its OIDC
 # claims, even if the role is not listed in repo_role_mappings above. Roles in
@@ -389,3 +368,24 @@ tag_auth:
 # All present aow/* tags must pass (AND); a space-separated value means OR.
 # A role with no aow/repo or aow/repo-owner tag is never assumable via tag-auth.
 # Matching is EXACT (AWS tag values cannot hold regex), unlike repo_role_mappings.
+
+# JWT Validation Mode
+# Controls who validates the JWT signature.
+#
+# "self"  (default) - Full signature verification by this service using JWKS.
+#                     Required when no trusted upstream service pre-validates tokens.
+#
+# "apigw" - Trust API Gateway HTTP API v2 JWT Authorizer. Claims are read from
+#           event.requestContext.authorizer.jwt.claims. No re-validation by Lambda.
+#           Use with cmd/apigatewayv2/ binary. Configure API GW JWT Authorizer with
+#           issuerUrl: https://token.actions.githubusercontent.com and the expected audience.
+#           SECURITY: Restrict Lambda invocations to the API Gateway resource via
+#           Lambda resource-based policies to prevent direct invocation bypass.
+#
+# "alb"   - Trust ALB OIDC authentication. The x-amzn-oidc-data header JWT
+#           (ALB-signed with ES256) is verified. Suitable when ALB is configured
+#           with GitHub OIDC as identity provider.
+#           alb_expected_signer should be set to the ALB ARN to prevent spoofing.
+jwt_validation:
+  mode: "self"
+  # alb_expected_signer: "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc"

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -334,6 +334,27 @@ repo_role_mappings:
       - arn:aws:iam::123456789012:role/github-actions-default-fallback
     # No constraints means this applies to all branches/events
 
+# JWT Validation Mode
+# Controls who validates the JWT signature.
+#
+# "self"  (default) - Full signature verification by this service using JWKS.
+#                     Required when no trusted upstream service pre-validates tokens.
+#
+# "apigw" - Trust API Gateway HTTP API v2 JWT Authorizer. Claims are read from
+#           event.requestContext.authorizer.jwt.claims. No re-validation by Lambda.
+#           Use with cmd/apigatewayv2/ binary. Configure API GW JWT Authorizer with
+#           issuerUrl: https://token.actions.githubusercontent.com and the expected audience.
+#           SECURITY: Restrict Lambda invocations to the API Gateway resource via
+#           Lambda resource-based policies to prevent direct invocation bypass.
+#
+# "alb"   - Trust ALB OIDC authentication. The x-amzn-oidc-data header JWT
+#           (ALB-signed with ES256) is verified. Suitable when ALB is configured
+#           with GitHub OIDC as identity provider.
+#           alb_expected_signer should be set to the ALB ARN to prevent spoofing.
+jwt_validation:
+  mode: "self"
+  # alb_expected_signer: "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc"
+
 # Tag-based authorization (optional, default disabled).
 # When enabled, a repo may assume a role whose IAM tags authorize its OIDC
 # claims, even if the role is not listed in repo_role_mappings above. Roles in

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -388,4 +388,4 @@ tag_auth:
 #           alb_expected_signer should be set to the ALB ARN to prevent spoofing.
 jwt_validation:
   mode: "self"
-  # alb_expected_signer: "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc"
+  # alb_expected_signer: "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc"  # required (not optional) when mode is "alb"

--- a/internal/config/CLAUDE.md
+++ b/internal/config/CLAUDE.md
@@ -10,7 +10,8 @@ Extends [../../CLAUDE.md](../../CLAUDE.md). Viper-based loading, validation, and
 
 ## Key structures & methods
 
-- `Config` — issuer, `audiences` (plus deprecated `audience`), S3 config/policy buckets, `repo_role_mappings`, logging, `cache`.
+- `Config` — issuer, `audiences` (plus deprecated `audience`), S3 config/policy buckets, `repo_role_mappings`, logging, `cache`, `JWTValidation`.
+- `JWTValidation` — `Mode` (`"self"` default, `"apigw"`, `"alb"`) and `ALBExpectedSigner` (ARN of the trusted ALB; optional but strongly recommended in `alb` mode). Env: `AOW_JWT_VALIDATION_MODE`, `AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER`. `Validate()` rejects unknown modes.
 - `RepoRoleMapping` — `repo` pattern, `roles`, optional `session_policy`/`session_policy_file`, optional `constraints`.
 - `Constraint` — `branch`, `ref`, `ref_type`, `event_name`, `workflow_ref`, `environment`, `actor_matches`. All present constraints must match (AND).
 - `Validate()` — compiles all regex patterns once; repo patterns auto-anchored `^(?:pattern)$`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,21 @@ type TagAuth struct {
 	AllowedAccounts []string `mapstructure:"allowed_accounts" json:"allowed_accounts,omitempty"`
 }
 
+// JWTValidation controls whether the service validates JWT signatures itself
+// or trusts pre-validation by an upstream AWS service.
+type JWTValidation struct {
+	// Mode is one of "self" (default), "apigw", or "alb".
+	// "self"  — full signature + claims verification by this service.
+	// "apigw" — trust API Gateway HTTP API v2 JWT Authorizer; extract claims
+	//            from event.requestContext.authorizer.jwt.claims.
+	// "alb"   — trust ALB OIDC; verify ALB-signed x-amzn-oidc-data JWT (ES256).
+	Mode string `mapstructure:"mode" json:"mode,omitempty"`
+
+	// ALBExpectedSigner is the ARN of the ALB allowed to sign OIDC data.
+	// Optional but recommended in "alb" mode to prevent cross-ALB attacks.
+	ALBExpectedSigner string `mapstructure:"alb_expected_signer" json:"alb_expected_signer,omitempty"`
+}
+
 type Config struct {
 	Issuer                string            `mapstructure:"issuer"                json:"issuer"`                          // Issuer is the expected issuer of the JWT token
 	Audience              string            `mapstructure:"audience"              json:"audience,omitempty"`              // Audience is the expected audience of the JWT token (deprecated - use Audiences)
@@ -112,6 +127,10 @@ type Config struct {
 
 	// TagAuth enables tag-based authorization and cross-account role assumption.
 	TagAuth *TagAuth `mapstructure:"tag_auth" json:"tag_auth,omitempty"`
+
+	// JWTValidation controls whether the service validates JWT signatures itself
+	// or trusts pre-validation by an upstream AWS service.
+	JWTValidation JWTValidation `mapstructure:"jwt_validation" json:"jwt_validation,omitempty"`
 
 	// Performance optimization - not serialized
 	estimatedRolesPerRepo int `mapstructure:"-" json:"-"` // Calculated during Validate for efficient memory allocation
@@ -155,6 +174,7 @@ func (c *Config) LoadConfig() error {
 	viper.SetDefault("tag_auth.spoke_role_name", "aow-spoke")
 	viper.SetDefault("tag_auth.spoke_session_duration", "15m")
 	viper.SetDefault("tag_auth.transitive_session_tags", false)
+	viper.SetDefault("jwt_validation.mode", "self")
 
 	// Explicitly bind all config keys to environment variables
 	// Core settings
@@ -190,6 +210,10 @@ func (c *Config) LoadConfig() error {
 	_ = viper.BindEnv("tag_auth.spoke_session_duration")  // AOW_TAG_AUTH_SPOKE_SESSION_DURATION
 	_ = viper.BindEnv("tag_auth.transitive_session_tags") // AOW_TAG_AUTH_TRANSITIVE_SESSION_TAGS
 	_ = viper.BindEnv("tag_auth.allowed_accounts")        // AOW_TAG_AUTH_ALLOWED_ACCOUNTS (comma-separated)
+
+	// JWT validation settings
+	_ = viper.BindEnv("jwt_validation.mode")                // AOW_JWT_VALIDATION_MODE
+	_ = viper.BindEnv("jwt_validation.alb_expected_signer") // AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER
 
 	// Logging settings
 	_ = viper.BindEnv("log_to_s3")
@@ -504,6 +528,20 @@ func (c *Config) Validate() error {
 				slog.Warn("tag_auth enabled with empty allowed_accounts; the warden may assume into ANY member account. Populate tag_auth.allowed_accounts in production.")
 			}
 		}
+	}
+
+	// Validate jwt_validation.mode, defaulting to "self" if not set.
+	if c.JWTValidation.Mode == "" {
+		c.JWTValidation.Mode = "self"
+	}
+	validModes := map[string]bool{"self": true, "apigw": true, "alb": true}
+	if !validModes[c.JWTValidation.Mode] {
+		return fmt.Errorf("jwt_validation.mode must be one of 'self', 'apigw', 'alb'; got %q", c.JWTValidation.Mode)
+	}
+	// alb_expected_signer is required in alb mode — without it any ALB can inject
+	// a signed OIDC header and impersonate any GitHub repository (cross-ALB spoofing).
+	if c.JWTValidation.Mode == "alb" && c.JWTValidation.ALBExpectedSigner == "" {
+		return fmt.Errorf("jwt_validation.alb_expected_signer is required in alb mode to prevent cross-ALB token injection")
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -398,6 +398,15 @@ func reapplyEnvOverrides(c *Config) {
 		}
 		c.TagAuth.AllowedAccounts = accts
 	}
+
+	// JWT validation env overrides — must be re-applied after hot-reload so
+	// that AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER is never silently dropped.
+	if v := os.Getenv("AOW_JWT_VALIDATION_MODE"); v != "" {
+		c.JWTValidation.Mode = v
+	}
+	if v := os.Getenv("AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER"); v != "" {
+		c.JWTValidation.ALBExpectedSigner = v
+	}
 }
 
 // FormatFromPath returns the viper config type implied by a file path's

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,7 +99,7 @@ type JWTValidation struct {
 	Mode string `mapstructure:"mode" json:"mode,omitempty"`
 
 	// ALBExpectedSigner is the ARN of the ALB allowed to sign OIDC data.
-	// Optional but recommended in "alb" mode to prevent cross-ALB attacks.
+	// Required in "alb" mode to prevent cross-ALB token injection.
 	ALBExpectedSigner string `mapstructure:"alb_expected_signer" json:"alb_expected_signer,omitempty"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -559,6 +559,36 @@ func TestTagAuthDefaults(t *testing.T) {
 	assert.Equal(t, "aow-spoke", c.TagAuth.SpokeRoleName)
 }
 
+func TestReapplyEnvOverrides_JWTValidation(t *testing.T) {
+	// AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER must survive a MergeBytes hot-reload.
+	// Without the fix, MergeBytes would silently drop env-var overrides for these
+	// fields, potentially removing the cross-ALB signer guard.
+	const signer = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc123"
+
+	t.Setenv("AOW_JWT_VALIDATION_MODE", "alb")
+	t.Setenv("AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER", signer)
+
+	cfg := &Config{
+		Issuer:          "https://token.actions.githubusercontent.com",
+		Audiences:       []string{"sts.amazonaws.com"},
+		RoleSessionName: "test-session",
+		JWTValidation: JWTValidation{
+			Mode:              "alb",
+			ALBExpectedSigner: signer,
+		},
+	}
+
+	// Simulate a remote config reload that omits jwt_validation entirely
+	// (the S3 document doesn't include it, so it would revert to zero values
+	// without reapplyEnvOverrides).
+	payload := []byte(`{"issuer":"https://token.actions.githubusercontent.com","audiences":["sts.amazonaws.com"],"role_session_name":"test-session"}`)
+	err := cfg.MergeBytes(payload, "json")
+	require.NoError(t, err)
+
+	assert.Equal(t, "alb", cfg.JWTValidation.Mode)
+	assert.Equal(t, signer, cfg.JWTValidation.ALBExpectedSigner)
+}
+
 func TestJWTValidationConfig(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -561,57 +561,62 @@ func TestTagAuthDefaults(t *testing.T) {
 
 func TestJWTValidationConfig(t *testing.T) {
 	tests := []struct {
-		name    string
-		env     map[string]string
-		wantErr bool
+		name       string
+		env        map[string]string
+		wantErr    bool
+		wantMode   string
+		wantSigner string
 	}{
-		{"default self", nil, false},
-		{"apigw mode", map[string]string{"AOW_JWT_VALIDATION_MODE": "apigw"}, false},
-		{"invalid mode", map[string]string{"AOW_JWT_VALIDATION_MODE": "bad"}, true},
-		{"alb missing signer", map[string]string{"AOW_JWT_VALIDATION_MODE": "alb"}, true},
+		{"default self", nil, false, "self", ""},
+		{"apigw mode", map[string]string{"AOW_JWT_VALIDATION_MODE": "apigw"}, false, "apigw", ""},
+		{"invalid mode", map[string]string{"AOW_JWT_VALIDATION_MODE": "bad"}, true, "", ""},
+		{"alb missing signer", map[string]string{"AOW_JWT_VALIDATION_MODE": "alb"}, true, "", ""},
 		{"alb with signer", map[string]string{
 			"AOW_JWT_VALIDATION_MODE":                "alb",
 			"AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER": "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/x/y",
-		}, false},
+		}, false, "alb", "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/x/y"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper and singleton to ensure clean state for this test
+			viper.Reset()
+			once = sync.Once{}
+
+			// Save and restore CONFIG_NAME to avoid config file lookups
+			origConfigName := os.Getenv("CONFIG_NAME")
+			defer func() {
+				if origConfigName == "" {
+					_ = os.Unsetenv("CONFIG_NAME")
+				} else {
+					_ = os.Setenv("CONFIG_NAME", origConfigName)
+				}
+			}()
+
+			// Point to nonexistent config file to force defaults
+			t.Setenv("CONFIG_NAME", "nonexistent-config-file")
+
+			// Set required fields and JWT validation env vars
+			t.Setenv("AOW_ISSUER", "https://token.actions.githubusercontent.com")
+			t.Setenv("AOW_AUDIENCES", "sts.amazonaws.com")
+			t.Setenv("AOW_ROLE_SESSION_NAME", "test-session")
+
+			// Set test-specific JWT validation env vars
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
-			cfg := &Config{
-				Issuer:          "https://token.actions.githubusercontent.com",
-				Audiences:       []string{"sts.amazonaws.com"},
-				RoleSessionName: "test-session",
-				JWTValidation: JWTValidation{Mode: func() string {
-					if tt.env != nil {
-						if mode, ok := tt.env["AOW_JWT_VALIDATION_MODE"]; ok {
-							return mode
-						}
-					}
-					return "self"
-				}(),
-					ALBExpectedSigner: func() string {
-						if tt.env != nil {
-							if signer, ok := tt.env["AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER"]; ok {
-								return signer
-							}
-						}
-						return ""
-					}(),
-				},
-			}
-			err := cfg.Validate()
+
+			// Load config through viper so env vars flow through the binding path.
+			// LoadConfig() calls Validate() internally, so validation errors occur here.
+			cfg := &Config{}
+			err := cfg.LoadConfig()
+
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			expectedMode := "self"
-			if tt.env != nil && tt.env["AOW_JWT_VALIDATION_MODE"] != "" {
-				expectedMode = tt.env["AOW_JWT_VALIDATION_MODE"]
-			}
-			assert.Equal(t, expectedMode, cfg.JWTValidation.Mode)
+			assert.Equal(t, tt.wantMode, cfg.JWTValidation.Mode)
+			assert.Equal(t, tt.wantSigner, cfg.JWTValidation.ALBExpectedSigner)
 		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -558,3 +558,60 @@ func TestTagAuthDefaults(t *testing.T) {
 	assert.Equal(t, "aow/", c.TagAuth.TagPrefix)
 	assert.Equal(t, "aow-spoke", c.TagAuth.SpokeRoleName)
 }
+
+func TestJWTValidationConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		wantErr bool
+	}{
+		{"default self", nil, false},
+		{"apigw mode", map[string]string{"AOW_JWT_VALIDATION_MODE": "apigw"}, false},
+		{"invalid mode", map[string]string{"AOW_JWT_VALIDATION_MODE": "bad"}, true},
+		{"alb missing signer", map[string]string{"AOW_JWT_VALIDATION_MODE": "alb"}, true},
+		{"alb with signer", map[string]string{
+			"AOW_JWT_VALIDATION_MODE":                "alb",
+			"AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER": "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/x/y",
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			cfg := &Config{
+				Issuer:          "https://token.actions.githubusercontent.com",
+				Audiences:       []string{"sts.amazonaws.com"},
+				RoleSessionName: "test-session",
+				JWTValidation: JWTValidation{Mode: func() string {
+					if tt.env != nil {
+						if mode, ok := tt.env["AOW_JWT_VALIDATION_MODE"]; ok {
+							return mode
+						}
+					}
+					return "self"
+				}(),
+					ALBExpectedSigner: func() string {
+						if tt.env != nil {
+							if signer, ok := tt.env["AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER"]; ok {
+								return signer
+							}
+						}
+						return ""
+					}(),
+				},
+			}
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			expectedMode := "self"
+			if tt.env != nil && tt.env["AOW_JWT_VALIDATION_MODE"] != "" {
+				expectedMode = tt.env["AOW_JWT_VALIDATION_MODE"]
+			}
+			assert.Equal(t, expectedMode, cfg.JWTValidation.Mode)
+		})
+	}
+}

--- a/internal/handler/CLAUDE.md
+++ b/internal/handler/CLAUDE.md
@@ -4,23 +4,33 @@ Extends [../../CLAUDE.md](../../CLAUDE.md). Core request logic shared by all dep
 
 ## Files
 
-- `bootstrap.go` — `NewBootstrap()` wires dependencies (config, validator, cache, AWS consumer).
-- `processor.go` — `ProcessRequest()` is the pipeline; `getSessionPolicy()` resolves inline-or-S3 policy.
-- `types.go` — `RequestData`/response structs and sentinel errors (`ErrRoleNotPermitted`, `ErrSessionPolicyAccess`, …).
-- `validation.go` — input validation helpers.
-- `apigateway.go` / `lambdaurl.go` / `alb.go` — frontend adapters. Identical business logic; only event parse/serialize differs.
+- `bootstrap.go` — `NewBootstrap()` wires dependencies; constructs the correct `ClaimsExtractorInterface` from `cfg.JWTValidation.Mode`. Holds both `Validator` (kept for external use) and `Extractor` (used by processor).
+- `processor.go` — `ProcessRequest(ctx, requestData, input, requestID, log)`. Takes `ExtractionInput` and calls `extractor.Extract()` instead of `validator.Validate()` directly.
+- `types.go` — `RequestData`/response structs and sentinel errors. In delegated modes, `RequestData.Token` may be empty.
+- `validation.go` — `ValidateRequestData` (self mode), `ParseRoleOnlyRequestBody` (delegated modes — only `role` required), shared `validateRole()` helper.
+- `apigateway.go` — REST API v1 adapter (`events.APIGatewayProxyRequest`). Passes `ExtractionInput{Token: requestData.Token}`; always self mode.
+- `apigatewayv2.go` — HTTP API v2 adapter (`events.APIGatewayV2HTTPRequest`). Reads authorizer claims from `event.RequestContext.Authorizer.JWT.Claims`; use with `jwt_validation.mode: "apigw"`.
+- `alb.go` — ALB adapter. Reads `x-amzn-oidc-data` header when present (delegated ALB mode); falls back to token-in-body (self mode).
+- `lambdaurl.go` — Lambda URL adapter. Always self mode.
 
-Pipeline: `MaybeRefresh()` config snapshot → token validation → account allow-list guard (if `tag_auth.enabled`) → `MatchRolesToRepoWithConstraints` (explicit) → tag-auth fallback (`GetRoleTags` + `TagAuth.Authorize`, if enabled and explicit match failed) → session policy resolution → role assumption.
+## Pipeline
+
+`MaybeRefresh()` → `extractor.Extract(ctx, input)` → account allow-list guard → `MatchRolesToRepoWithConstraints` → tag-auth fallback → session policy → role assumption.
 
 ## Conventions
 
-- Entry points construct via `NewBootstrap()` then the matching `New…FromBootstrap`; always `defer bootstrap.Cleanup()` — it flushes S3 logs.
+- Entry points construct via `NewBootstrap()` then the matching `New…FromBootstrap`; always `defer bootstrap.Cleanup()`.
+- `ClaimsExtractorInterface` is the only way claims enter `ProcessRequest` — never call `validator.Validate()` directly from adapters.
+- In delegated mode, if the upstream injects no claims, `Extract()` returns an error that wraps `ErrTokenValidationFailed` — the bypass-prevention guard.
+- `ParseRoleOnlyRequestBody` must be used by delegated adapters; `ParseRequestBody` requires a non-empty token.
 - Classify failures with sentinel errors in `types.go`; adapters map them to HTTP status via `errors.Is`.
-- Structured logging with request context (`slog.With` + `slog.Group`); redact tokens with `utils.RedactToken` before logging.
-- Test with `TokenValidatorInterface` / `AwsConsumerInterface` mocks; cover error paths.
+- Structured logging with request context (`slog.With`); redact tokens with `utils.RedactToken` before logging.
+- Test processor with `ClaimsExtractorInterface` mocks (not `TokenValidatorInterface`); the latter is for `SelfExtractor` unit tests only.
 
 ## Gotchas
 
+- `apigatewayv2.go` is the only adapter compatible with API Gateway JWT Authorizer — v1 REST API does not receive authorizer claims.
+- The extractor is created once at bootstrap; changing `jwt_validation.mode` at runtime requires a Lambda cold start.
 - Inline session policy overrides the S3 file when both are set.
-- S3 policy reads are bounded (`io.LimitReader`, 1MB).
+- S3 policy reads are bounded (`io.LimitReader`, 1 MB).
 - Start time is carried in context (`StartTimeContextKey`).

--- a/internal/handler/alb.go
+++ b/internal/handler/alb.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -23,9 +24,9 @@ type AwsApplicationLoadBalancer struct {
 }
 
 // NewAwsApplicationLoadBalancer creates a new Application Load Balancer handler
-func NewAwsApplicationLoadBalancer(provider *config.Provider, consumer aws.AwsConsumerInterface, validator validator.TokenValidatorInterface) *AwsApplicationLoadBalancer {
+func NewAwsApplicationLoadBalancer(provider *config.Provider, consumer aws.AwsConsumerInterface, extractor validator.ClaimsExtractorInterface) *AwsApplicationLoadBalancer {
 	return &AwsApplicationLoadBalancer{
-		processor: NewRequestProcessor(provider, consumer, validator),
+		processor: NewRequestProcessor(provider, consumer, extractor),
 	}
 }
 
@@ -51,8 +52,27 @@ func (h *AwsApplicationLoadBalancer) Handler(ctx context.Context, event events.A
 		return h.respondError(ctx, err, http.StatusBadRequest)
 	}
 
+	// Build extraction input: prefer ALB OIDC data header when present.
+	oidcData := event.Headers["x-amzn-oidc-data"]
+	region := os.Getenv("AWS_REGION")
+
+	// Bound x-amzn-oidc-data before any parsing.
+	if len(oidcData) > MaxTokenLength {
+		return h.respondError(ctx, fmt.Errorf("x-amzn-oidc-data header exceeds maximum allowed size"), http.StatusBadRequest)
+	}
+
+	var input validator.ExtractionInput
+	if oidcData != "" {
+		input = validator.ExtractionInput{
+			ALBOIDCData: oidcData,
+			AWSRegion:   region,
+		}
+	} else {
+		input = validator.ExtractionInput{Token: requestData.Token}
+	}
+
 	// Process the request using the request processor
-	credentials, err := h.processor.ProcessRequest(ctx, requestData, requestID, log)
+	credentials, err := h.processor.ProcessRequest(ctx, requestData, input, requestID, log)
 	if err != nil {
 		statusCode := http.StatusInternalServerError
 		switch {
@@ -88,8 +108,13 @@ func (h *AwsApplicationLoadBalancer) createRequestContext(ctx context.Context, e
 	return context.WithTimeout(ctx, DefaultTimeout)
 }
 
-// unmarshalRequestData parses and validates the request data from an ALB event
+// unmarshalRequestData parses and validates the request data from an ALB event.
+// When x-amzn-oidc-data is present the body only needs to carry the role (token
+// comes from the header), so we use the role-only parser in that case.
 func (h *AwsApplicationLoadBalancer) unmarshalRequestData(event events.ALBTargetGroupRequest) (*RequestData, error) {
+	if event.Headers["x-amzn-oidc-data"] != "" {
+		return ParseRoleOnlyRequestBody(event.Body)
+	}
 	return ParseRequestBody(event.Body)
 }
 

--- a/internal/handler/alb.go
+++ b/internal/handler/alb.go
@@ -20,12 +20,14 @@ import (
 // AwsApplicationLoadBalancer handles AWS Application Load Balancer requests
 type AwsApplicationLoadBalancer struct {
 	processor *RequestProcessor
+	region    string
 }
 
 // NewAwsApplicationLoadBalancer creates a new Application Load Balancer handler
 func NewAwsApplicationLoadBalancer(provider *config.Provider, consumer aws.AwsConsumerInterface, extractor validator.ClaimsExtractorInterface) *AwsApplicationLoadBalancer {
 	return &AwsApplicationLoadBalancer{
 		processor: NewRequestProcessor(provider, consumer, extractor),
+		region:    os.Getenv("AWS_REGION"),
 	}
 }
 
@@ -47,7 +49,7 @@ func (h *AwsApplicationLoadBalancer) Handler(ctx context.Context, event events.A
 
 	// Build extraction input: prefer ALB OIDC data header when present.
 	oidcData := event.Headers["x-amzn-oidc-data"]
-	region := os.Getenv("AWS_REGION")
+	region := h.region
 
 	// Bound before body parsing to reject oversized ALB OIDC headers early.
 	if len(oidcData) > MaxTokenLength {

--- a/internal/handler/alb.go
+++ b/internal/handler/alb.go
@@ -46,19 +46,19 @@ func (h *AwsApplicationLoadBalancer) Handler(ctx context.Context, event events.A
 		slog.String("userAgent", event.Headers["user-agent"]),
 	)
 
-	// Parse request data
-	requestData, err := h.unmarshalRequestData(event)
-	if err != nil {
-		return h.respondError(ctx, err, http.StatusBadRequest)
-	}
-
 	// Build extraction input: prefer ALB OIDC data header when present.
 	oidcData := event.Headers["x-amzn-oidc-data"]
 	region := os.Getenv("AWS_REGION")
 
-	// Bound x-amzn-oidc-data before any parsing.
+	// Bound before body parsing to reject oversized ALB OIDC headers early.
 	if len(oidcData) > MaxTokenLength {
 		return h.respondError(ctx, fmt.Errorf("x-amzn-oidc-data header exceeds maximum allowed size"), http.StatusBadRequest)
+	}
+
+	// Parse request data
+	requestData, err := h.unmarshalRequestData(event)
+	if err != nil {
+		return h.respondError(ctx, err, http.StatusBadRequest)
 	}
 
 	var input validator.ExtractionInput

--- a/internal/handler/alb.go
+++ b/internal/handler/alb.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -71,19 +70,11 @@ func (h *AwsApplicationLoadBalancer) Handler(ctx context.Context, event events.A
 		input = validator.ExtractionInput{Token: requestData.Token}
 	}
 
-	// Process the request using the request processor
+	// Process the request using the request processor.
+	// respondError classifies the error and sets the final status code.
 	credentials, err := h.processor.ProcessRequest(ctx, requestData, input, requestID, log)
 	if err != nil {
-		statusCode := http.StatusInternalServerError
-		switch {
-		case errors.Is(err, ErrTokenValidationFailed):
-			statusCode = http.StatusUnauthorized
-		case errors.Is(err, ErrRoleNotPermitted), errors.Is(err, ErrAccountNotAllowed):
-			statusCode = http.StatusForbidden
-		case errors.Is(err, ErrSessionPolicyAccess), errors.Is(err, ErrAssumeRoleFailed):
-			statusCode = http.StatusInternalServerError
-		}
-		return h.respondError(ctx, err, statusCode)
+		return h.respondError(ctx, err, http.StatusInternalServerError)
 	}
 
 	return h.respondJSON(ctx, credentials)
@@ -132,35 +123,8 @@ func (h *AwsApplicationLoadBalancer) respondError(ctx context.Context, err error
 		processingMS = time.Since(startTime).Milliseconds()
 	}
 
-	// Create structured error
-	errCode := "internal_error"
-	errMsg := "An internal error occurred"
-
-	// Map common errors to specific error codes and messages
-	switch {
-	case errors.Is(err, ErrEmptyToken), errors.Is(err, ErrTokenTooLarge),
-		errors.Is(err, ErrEmptyRole), errors.Is(err, ErrRoleTooLarge),
-		errors.Is(err, ErrInvalidJSON):
-		errCode = "invalid_request"
-		errMsg = "Invalid request parameters"
-		statusCode = http.StatusBadRequest
-	case errors.Is(err, ErrTokenValidationFailed):
-		errCode = "token_invalid"
-		errMsg = "Token validation failed"
-		statusCode = http.StatusUnauthorized
-	case errors.Is(err, ErrRoleNotPermitted), errors.Is(err, ErrAccountNotAllowed):
-		errCode = "permission_denied"
-		errMsg = "Permission denied for the requested operation"
-		statusCode = http.StatusForbidden
-	case errors.Is(err, ErrSessionPolicyAccess):
-		errCode = "policy_error"
-		errMsg = "Error accessing policy information"
-		statusCode = http.StatusInternalServerError
-	case errors.Is(err, ErrAssumeRoleFailed):
-		errCode = "assume_role_failed"
-		errMsg = "Failed to assume the requested role"
-		statusCode = http.StatusInternalServerError
-	}
+	// Map common errors to specific error codes and messages (shared classifier).
+	errCode, errMsg := classifyError(err, &statusCode)
 
 	// Log the error with context
 	slog.Error("Request error",

--- a/internal/handler/apigateway.go
+++ b/internal/handler/apigateway.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -59,16 +58,7 @@ func (h *AwsApiGateway) Handler(ctx context.Context, event events.APIGatewayProx
 	// Process the request using the request processor
 	credentials, err := h.processor.ProcessRequest(ctx, requestData, input, requestID, log)
 	if err != nil {
-		statusCode := http.StatusInternalServerError
-		switch {
-		case errors.Is(err, ErrTokenValidationFailed):
-			statusCode = http.StatusUnauthorized
-		case errors.Is(err, ErrRoleNotPermitted), errors.Is(err, ErrAccountNotAllowed):
-			statusCode = http.StatusForbidden
-		case errors.Is(err, ErrSessionPolicyAccess), errors.Is(err, ErrAssumeRoleFailed):
-			statusCode = http.StatusInternalServerError
-		}
-		return h.respondError(ctx, err, statusCode)
+		return h.respondError(ctx, err, http.StatusInternalServerError)
 	}
 
 	return h.respondJSON(ctx, credentials)

--- a/internal/handler/apigateway.go
+++ b/internal/handler/apigateway.go
@@ -23,9 +23,9 @@ type AwsApiGateway struct {
 }
 
 // NewAwsApiGateway creates a new API Gateway handler
-func NewAwsApiGateway(provider *config.Provider, consumer aws.AwsConsumerInterface, validator validator.TokenValidatorInterface) *AwsApiGateway {
+func NewAwsApiGateway(provider *config.Provider, consumer aws.AwsConsumerInterface, extractor validator.ClaimsExtractorInterface) *AwsApiGateway {
 	return &AwsApiGateway{
-		processor: NewRequestProcessor(provider, consumer, validator),
+		processor: NewRequestProcessor(provider, consumer, extractor),
 	}
 }
 
@@ -53,8 +53,11 @@ func (h *AwsApiGateway) Handler(ctx context.Context, event events.APIGatewayProx
 		return h.respondError(ctx, err, http.StatusBadRequest)
 	}
 
+	// Build extraction input from the parsed request token.
+	input := validator.ExtractionInput{Token: requestData.Token}
+
 	// Process the request using the request processor
-	credentials, err := h.processor.ProcessRequest(ctx, requestData, requestID, log)
+	credentials, err := h.processor.ProcessRequest(ctx, requestData, input, requestID, log)
 	if err != nil {
 		statusCode := http.StatusInternalServerError
 		switch {

--- a/internal/handler/apigateway.go
+++ b/internal/handler/apigateway.go
@@ -115,35 +115,8 @@ func (h *AwsApiGateway) respondError(ctx context.Context, err error, statusCode 
 		processingMS = time.Since(startTime).Milliseconds()
 	}
 
-	// Create structured error
-	errCode := "internal_error"
-	errMsg := "An internal error occurred"
-
-	// Map common errors to specific error codes and messages
-	switch {
-	case errors.Is(err, ErrEmptyToken), errors.Is(err, ErrTokenTooLarge),
-		errors.Is(err, ErrEmptyRole), errors.Is(err, ErrRoleTooLarge),
-		errors.Is(err, ErrInvalidJSON):
-		errCode = "invalid_request"
-		errMsg = "Invalid request parameters"
-		statusCode = http.StatusBadRequest
-	case errors.Is(err, ErrTokenValidationFailed):
-		errCode = "token_invalid"
-		errMsg = "Token validation failed"
-		statusCode = http.StatusUnauthorized
-	case errors.Is(err, ErrRoleNotPermitted), errors.Is(err, ErrAccountNotAllowed):
-		errCode = "permission_denied"
-		errMsg = "Permission denied for the requested operation"
-		statusCode = http.StatusForbidden
-	case errors.Is(err, ErrSessionPolicyAccess):
-		errCode = "policy_error"
-		errMsg = "Error accessing policy information"
-		statusCode = http.StatusInternalServerError
-	case errors.Is(err, ErrAssumeRoleFailed):
-		errCode = "assume_role_failed"
-		errMsg = "Failed to assume the requested role"
-		statusCode = http.StatusInternalServerError
-	}
+	// Map common errors to specific error codes and messages (shared classifier).
+	errCode, errMsg := classifyError(err, &statusCode)
 
 	// Log the error with context
 	slog.Error("Request error",

--- a/internal/handler/apigatewayv2.go
+++ b/internal/handler/apigatewayv2.go
@@ -1,0 +1,147 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/boogy/aws-oidc-warden/internal/aws"
+	"github.com/boogy/aws-oidc-warden/internal/config"
+	"github.com/boogy/aws-oidc-warden/internal/validator"
+	"github.com/google/uuid"
+)
+
+// AwsApiGatewayV2 handles AWS API Gateway HTTP API (v2) requests with a JWT Authorizer.
+// Use this adapter when API Gateway validates the JWT and passes claims via
+// event.requestContext.authorizer.jwt.claims. Set jwt_validation.mode: "apigw".
+type AwsApiGatewayV2 struct {
+	processor *RequestProcessor
+}
+
+// NewAwsApiGatewayV2 creates a new HTTP API v2 handler.
+func NewAwsApiGatewayV2(provider *config.Provider, consumer aws.AwsConsumerInterface, extractor validator.ClaimsExtractorInterface) *AwsApiGatewayV2 {
+	return &AwsApiGatewayV2{processor: NewRequestProcessor(provider, consumer, extractor)}
+}
+
+// Handler is the Lambda function interface for API Gateway HTTP API v2.
+func (h *AwsApiGatewayV2) Handler(ctx context.Context, event events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	ctx, cancel := h.createRequestContext(ctx, event)
+	defer cancel()
+	requestID, _ := ctx.Value(RequestIDContextKey).(string)
+
+	log := slog.With(
+		slog.String("requestId", requestID),
+		slog.String("path", event.RawPath),
+		slog.String("method", event.RequestContext.HTTP.Method),
+		slog.String("sourceIp", event.RequestContext.HTTP.SourceIP),
+		slog.String("userAgent", event.RequestContext.HTTP.UserAgent),
+	)
+
+	requestData, err := ParseRoleOnlyRequestBody(event.Body)
+	if err != nil {
+		return h.respondError(ctx, err, http.StatusBadRequest)
+	}
+
+	// Extract claims from API Gateway JWT Authorizer context.
+	var authorizerClaims map[string]string
+	if event.RequestContext.Authorizer != nil && event.RequestContext.Authorizer.JWT != nil {
+		authorizerClaims = event.RequestContext.Authorizer.JWT.Claims
+	}
+	input := validator.ExtractionInput{AuthorizerClaims: authorizerClaims}
+
+	credentials, err := h.processor.ProcessRequest(ctx, requestData, input, requestID, log)
+	if err != nil {
+		statusCode := http.StatusInternalServerError
+		switch {
+		case errors.Is(err, ErrTokenValidationFailed):
+			statusCode = http.StatusUnauthorized
+		case errors.Is(err, ErrRoleNotPermitted), errors.Is(err, ErrAccountNotAllowed):
+			statusCode = http.StatusForbidden
+		case errors.Is(err, ErrSessionPolicyAccess), errors.Is(err, ErrAssumeRoleFailed):
+			statusCode = http.StatusInternalServerError
+		}
+		return h.respondError(ctx, err, statusCode)
+	}
+	return h.respondJSON(ctx, credentials)
+}
+
+func (h *AwsApiGatewayV2) createRequestContext(ctx context.Context, event events.APIGatewayV2HTTPRequest) (context.Context, context.CancelFunc) {
+	requestID := event.RequestContext.RequestID
+	if requestID == "" {
+		requestID = uuid.New().String()
+	}
+	ctx = context.WithValue(ctx, RequestIDContextKey, requestID)
+	ctx = context.WithValue(ctx, StartTimeContextKey, time.Now())
+	ctx = context.WithValue(ctx, SourceIPContextKey, event.RequestContext.HTTP.SourceIP)
+	ctx = context.WithValue(ctx, UserAgentContextKey, event.RequestContext.HTTP.UserAgent)
+	return context.WithTimeout(ctx, DefaultTimeout)
+}
+
+func (h *AwsApiGatewayV2) respondError(ctx context.Context, err error, statusCode int) (events.APIGatewayV2HTTPResponse, error) {
+	requestID, _ := ctx.Value(RequestIDContextKey).(string)
+	if requestID == "" {
+		requestID = uuid.New().String()
+	}
+	var processingMS int64
+	if startTime, ok := ctx.Value(StartTimeContextKey).(time.Time); ok {
+		processingMS = time.Since(startTime).Milliseconds()
+	}
+	errCode, errMsg := classifyError(err, &statusCode)
+	slog.Error("Request error",
+		slog.String("requestId", requestID),
+		slog.String("errorCode", errCode),
+		slog.String("error", err.Error()),
+		slog.Int("status", statusCode),
+		slog.Int64("processingMs", processingMS))
+	response := Response{
+		Success:      false,
+		StatusCode:   statusCode,
+		ErrorCode:    errCode,
+		Message:      errMsg,
+		ErrorDetails: err.Error(),
+		RequestID:    requestID,
+		ProcessingMS: processingMS,
+	}
+	body, jsonErr := json.Marshal(response)
+	if jsonErr != nil {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Headers:    ResponseHeaders,
+			Body:       fmt.Sprintf(`{"error":"%s"}`, err.Error()),
+		}, nil
+	}
+	return events.APIGatewayV2HTTPResponse{StatusCode: statusCode, Headers: ResponseHeaders, Body: string(body)}, nil
+}
+
+func (h *AwsApiGatewayV2) respondJSON(ctx context.Context, credentials *types.Credentials) (events.APIGatewayV2HTTPResponse, error) {
+	requestID, _ := ctx.Value(RequestIDContextKey).(string)
+	if requestID == "" {
+		requestID = uuid.New().String()
+	}
+	var processingMS int64
+	if startTime, ok := ctx.Value(StartTimeContextKey).(time.Time); ok {
+		processingMS = time.Since(startTime).Milliseconds()
+	}
+	response := Response{
+		Success:      true,
+		StatusCode:   http.StatusOK,
+		Message:      "Claims extracted and role assumed",
+		RequestID:    requestID,
+		ProcessingMS: processingMS,
+		Data:         credentials,
+	}
+	body, err := json.Marshal(response)
+	if err != nil {
+		return h.respondError(ctx, fmt.Errorf("failed to marshal response: %w", err), http.StatusInternalServerError)
+	}
+	slog.Debug("Response successful",
+		slog.String("requestId", requestID),
+		slog.Int64("processingMs", processingMS))
+	return events.APIGatewayV2HTTPResponse{StatusCode: http.StatusOK, Headers: ResponseHeaders, Body: string(body)}, nil
+}

--- a/internal/handler/apigatewayv2.go
+++ b/internal/handler/apigatewayv2.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -57,16 +56,7 @@ func (h *AwsApiGatewayV2) Handler(ctx context.Context, event events.APIGatewayV2
 
 	credentials, err := h.processor.ProcessRequest(ctx, requestData, input, requestID, log)
 	if err != nil {
-		statusCode := http.StatusInternalServerError
-		switch {
-		case errors.Is(err, ErrTokenValidationFailed):
-			statusCode = http.StatusUnauthorized
-		case errors.Is(err, ErrRoleNotPermitted), errors.Is(err, ErrAccountNotAllowed):
-			statusCode = http.StatusForbidden
-		case errors.Is(err, ErrSessionPolicyAccess), errors.Is(err, ErrAssumeRoleFailed):
-			statusCode = http.StatusInternalServerError
-		}
-		return h.respondError(ctx, err, statusCode)
+		return h.respondError(ctx, err, http.StatusInternalServerError)
 	}
 	return h.respondJSON(ctx, credentials)
 }

--- a/internal/handler/apigatewayv2.go
+++ b/internal/handler/apigatewayv2.go
@@ -121,7 +121,7 @@ func (h *AwsApiGatewayV2) respondJSON(ctx context.Context, credentials *types.Cr
 	response := Response{
 		Success:      true,
 		StatusCode:   http.StatusOK,
-		Message:      "Claims extracted and role assumed",
+		Message:      "Token validation successful and role assumed",
 		RequestID:    requestID,
 		ProcessingMS: processingMS,
 		Data:         credentials,

--- a/internal/handler/apigatewayv2_test.go
+++ b/internal/handler/apigatewayv2_test.go
@@ -1,0 +1,61 @@
+package handler_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/boogy/aws-oidc-warden/internal/handler"
+	"github.com/boogy/aws-oidc-warden/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAwsApiGatewayV2_Handler_ExtractsClaims(t *testing.T) {
+	event := events.APIGatewayV2HTTPRequest{
+		Body: `{"role":"arn:aws:iam::123456789012:role/MyRole"}`,
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
+			Authorizer: &events.APIGatewayV2HTTPRequestContextAuthorizerDescription{
+				JWT: &events.APIGatewayV2HTTPRequestContextAuthorizerJWTDescription{
+					Claims: map[string]string{
+						"iss":        "https://token.actions.githubusercontent.com",
+						"repository": "org/repo",
+						"ref":        "refs/heads/main",
+						"ref_type":   "branch",
+						"actor":      "octocat",
+						"exp":        "9999999999",
+						"iat":        "1000000000",
+					},
+				},
+			},
+		},
+	}
+
+	// Use a fixed extractor so claims are returned directly without token validation.
+	// This isolates the adapter's routing logic from the extractor implementation.
+	ex := &fixedExtractor{claims: &types.GithubClaims{
+		Repository: "org/repo",
+		Ref:        "refs/heads/main",
+		Actor:      "octocat",
+	}}
+
+	h := handler.NewAwsApiGatewayV2(staticProvider(t), mockConsumer(t), ex)
+	resp, err := h.Handler(context.Background(), event)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestAwsApiGatewayV2_Handler_MissingAuthorizer(t *testing.T) {
+	// No authorizer claims → extractor should reject with ErrTokenValidationFailed → 401.
+	event := events.APIGatewayV2HTTPRequest{
+		Body: `{"role":"arn:aws:iam::123456789012:role/MyRole"}`,
+	}
+
+	// Use a stub extractor that always fails (simulates missing authorizer context).
+	ex := &stubExtractor{err: handler.ErrTokenValidationFailed}
+
+	h := handler.NewAwsApiGatewayV2(staticProvider(t), mockConsumer(t), ex)
+	resp, err := h.Handler(context.Background(), event)
+	require.NoError(t, err)
+	assert.Equal(t, 401, resp.StatusCode)
+}

--- a/internal/handler/bootstrap.go
+++ b/internal/handler/bootstrap.go
@@ -220,22 +220,44 @@ func initializeLogger() (*bytes.Buffer, *slog.Logger, error) {
 	return logBuffer, logger, nil
 }
 
+// validateAdapterMode panics at startup when the configured jwt_validation.mode
+// is incompatible with the deployed adapter binary. Prevents silent per-request
+// failures caused by a mismatched extractor (e.g. mode=apigw deployed as apigateway).
+func validateAdapterMode(adapterName, mode string, allowed ...string) {
+	if mode == "" {
+		mode = "self"
+	}
+	for _, m := range allowed {
+		if mode == m {
+			return
+		}
+	}
+	panic(fmt.Sprintf(
+		"adapter %q requires jwt_validation.mode in %v, got %q; deploy the correct binary or update the config",
+		adapterName, allowed, mode,
+	))
+}
+
 // NewAwsApiGatewayFromBootstrap creates a new API Gateway handler using bootstrap
 func NewAwsApiGatewayFromBootstrap(bootstrap *Bootstrap) *AwsApiGateway {
+	validateAdapterMode("apigateway", bootstrap.Config.JWTValidation.Mode, "self")
 	return NewAwsApiGateway(bootstrap.Provider, bootstrap.Consumer, bootstrap.Extractor)
 }
 
 // NewAwsLambdaUrlFromBootstrap creates a new Lambda URL handler using bootstrap
 func NewAwsLambdaUrlFromBootstrap(bootstrap *Bootstrap) *AwsLambdaUrl {
+	validateAdapterMode("lambdaurl", bootstrap.Config.JWTValidation.Mode, "self")
 	return NewAwsLambdaUrl(bootstrap.Provider, bootstrap.Consumer, bootstrap.Extractor)
 }
 
 // NewAwsApplicationLoadBalancerFromBootstrap creates a new ALB handler using bootstrap
 func NewAwsApplicationLoadBalancerFromBootstrap(bootstrap *Bootstrap) *AwsApplicationLoadBalancer {
+	validateAdapterMode("alb", bootstrap.Config.JWTValidation.Mode, "alb", "self")
 	return NewAwsApplicationLoadBalancer(bootstrap.Provider, bootstrap.Consumer, bootstrap.Extractor)
 }
 
 // NewAwsApiGatewayV2FromBootstrap creates a new HTTP API v2 handler using bootstrap
 func NewAwsApiGatewayV2FromBootstrap(bootstrap *Bootstrap) *AwsApiGatewayV2 {
+	validateAdapterMode("apigatewayv2", bootstrap.Config.JWTValidation.Mode, "apigw")
 	return NewAwsApiGatewayV2(bootstrap.Provider, bootstrap.Consumer, bootstrap.Extractor)
 }

--- a/internal/handler/bootstrap.go
+++ b/internal/handler/bootstrap.go
@@ -234,3 +234,8 @@ func NewAwsLambdaUrlFromBootstrap(bootstrap *Bootstrap) *AwsLambdaUrl {
 func NewAwsApplicationLoadBalancerFromBootstrap(bootstrap *Bootstrap) *AwsApplicationLoadBalancer {
 	return NewAwsApplicationLoadBalancer(bootstrap.Provider, bootstrap.Consumer, bootstrap.Extractor)
 }
+
+// NewAwsApiGatewayV2FromBootstrap creates a new HTTP API v2 handler using bootstrap
+func NewAwsApiGatewayV2FromBootstrap(bootstrap *Bootstrap) *AwsApiGatewayV2 {
+	return NewAwsApiGatewayV2(bootstrap.Provider, bootstrap.Consumer, bootstrap.Extractor)
+}

--- a/internal/handler/bootstrap.go
+++ b/internal/handler/bootstrap.go
@@ -22,7 +22,8 @@ type Bootstrap struct {
 	Config    *config.Config
 	Provider  *config.Provider
 	Consumer  aws.AwsConsumerInterface
-	Validator validator.TokenValidatorInterface
+	Validator validator.TokenValidatorInterface  // kept for external use / tests
+	Extractor validator.ClaimsExtractorInterface // used by processor
 	Cache     cache.Cache
 	S3Logger  *s3logger.S3Logger
 	Logger    *slog.Logger
@@ -87,16 +88,52 @@ func NewBootstrap() (*Bootstrap, error) {
 	// changes take effect immediately without a Lambda restart.
 	tokenValidator := validator.NewTokenValidatorFromProvider(provider, jwksCache)
 
+	// The extractor is fixed at cold start. Changing jwt_validation.mode at runtime
+	// requires a Lambda redeployment. Hot-reload via Provider only affects fields
+	// read per-request (repo_role_mappings, audiences, etc.).
+	extractor, err := newClaimsExtractor(cfg, tokenValidator)
+	if err != nil {
+		logger.Error("Failed to create claims extractor", slog.String("error", err.Error()))
+		return nil, fmt.Errorf("failed to create claims extractor: %w", err)
+	}
+	if cfg.JWTValidation.Mode != "self" {
+		logger.Warn("JWT validation delegated to upstream",
+			slog.String("mode", cfg.JWTValidation.Mode))
+	}
+
 	return &Bootstrap{
 		Config:    cfg,
 		Provider:  provider,
 		Consumer:  consumer,
 		Validator: tokenValidator,
+		Extractor: extractor,
 		Cache:     jwksCache,
 		S3Logger:  s3log,
 		Logger:    logger,
 		LogBuffer: logBuffer,
 	}, nil
+}
+
+// newClaimsExtractor creates the appropriate ClaimsExtractorInterface based on the configured mode.
+func newClaimsExtractor(cfg *config.Config, v validator.TokenValidatorInterface) (validator.ClaimsExtractorInterface, error) {
+	mode := cfg.JWTValidation.Mode
+	// Resolve audiences: prefer the slice, fall back to singular field.
+	audiences := cfg.Audiences
+	if len(audiences) == 0 && cfg.Audience != "" {
+		audiences = []string{cfg.Audience}
+	}
+	switch mode {
+	case "self", "":
+		return validator.NewSelfExtractor(v), nil
+	case "apigw":
+		// Pass issuer/audiences for defense-in-depth re-validation of pre-validated claims.
+		return validator.NewAPIGWExtractor(cfg.Issuer, audiences), nil
+	case "alb":
+		// Pass issuer/audiences for post-signature claim validation.
+		return validator.NewALBExtractor(cfg.JWTValidation.ALBExpectedSigner, cfg.Issuer, audiences), nil
+	default:
+		return nil, fmt.Errorf("unknown jwt_validation.mode: %q", mode)
+	}
 }
 
 // buildConfigProvider wires the config provider. With an S3 config source it
@@ -185,15 +222,15 @@ func initializeLogger() (*bytes.Buffer, *slog.Logger, error) {
 
 // NewAwsApiGatewayFromBootstrap creates a new API Gateway handler using bootstrap
 func NewAwsApiGatewayFromBootstrap(bootstrap *Bootstrap) *AwsApiGateway {
-	return NewAwsApiGateway(bootstrap.Provider, bootstrap.Consumer, bootstrap.Validator)
+	return NewAwsApiGateway(bootstrap.Provider, bootstrap.Consumer, bootstrap.Extractor)
 }
 
 // NewAwsLambdaUrlFromBootstrap creates a new Lambda URL handler using bootstrap
 func NewAwsLambdaUrlFromBootstrap(bootstrap *Bootstrap) *AwsLambdaUrl {
-	return NewAwsLambdaUrl(bootstrap.Provider, bootstrap.Consumer, bootstrap.Validator)
+	return NewAwsLambdaUrl(bootstrap.Provider, bootstrap.Consumer, bootstrap.Extractor)
 }
 
 // NewAwsApplicationLoadBalancerFromBootstrap creates a new ALB handler using bootstrap
 func NewAwsApplicationLoadBalancerFromBootstrap(bootstrap *Bootstrap) *AwsApplicationLoadBalancer {
-	return NewAwsApplicationLoadBalancer(bootstrap.Provider, bootstrap.Consumer, bootstrap.Validator)
+	return NewAwsApplicationLoadBalancer(bootstrap.Provider, bootstrap.Consumer, bootstrap.Extractor)
 }

--- a/internal/handler/bootstrap.go
+++ b/internal/handler/bootstrap.go
@@ -202,7 +202,7 @@ func initializeLogger() (*bytes.Buffer, *slog.Logger, error) {
 		if level, err := utils.ParseLogLevel(logLevel); err == nil {
 			programLevel.Set(level)
 		} else {
-			slog.Info("Invalid LOG_LEVEL %q, defaulting to Info: %v", logLevel, err)
+			slog.Warn("invalid LOG_LEVEL, defaulting to Info", "level", logLevel, "error", err)
 		}
 	}
 

--- a/internal/handler/errors.go
+++ b/internal/handler/errors.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+)
+
+// classifyError maps sentinel errors to an error code, human-readable message,
+// and (optionally) overrides statusCode. Shared by all frontend adapters to
+// avoid duplicating the switch in each respondError implementation.
+func classifyError(err error, statusCode *int) (errCode, errMsg string) {
+	errCode = "internal_error"
+	errMsg = "An internal error occurred"
+	switch {
+	case errors.Is(err, ErrEmptyToken), errors.Is(err, ErrTokenTooLarge),
+		errors.Is(err, ErrEmptyRole), errors.Is(err, ErrRoleTooLarge),
+		errors.Is(err, ErrInvalidJSON):
+		errCode = "invalid_request"
+		errMsg = "Invalid request parameters"
+		*statusCode = http.StatusBadRequest
+	case errors.Is(err, ErrTokenValidationFailed):
+		errCode = "token_invalid"
+		errMsg = "Token validation failed"
+		*statusCode = http.StatusUnauthorized
+	case errors.Is(err, ErrRoleNotPermitted), errors.Is(err, ErrAccountNotAllowed):
+		errCode = "permission_denied"
+		errMsg = "Permission denied for the requested operation"
+		*statusCode = http.StatusForbidden
+	case errors.Is(err, ErrSessionPolicyAccess):
+		errCode = "policy_error"
+		errMsg = "Error accessing policy information"
+		*statusCode = http.StatusInternalServerError
+	case errors.Is(err, ErrAssumeRoleFailed):
+		errCode = "assume_role_failed"
+		errMsg = "Failed to assume the requested role"
+		*statusCode = http.StatusInternalServerError
+	}
+	return
+}

--- a/internal/handler/errors.go
+++ b/internal/handler/errors.go
@@ -13,8 +13,8 @@ func classifyError(err error, statusCode *int) (errCode, errMsg string) {
 	errMsg = "An internal error occurred"
 	switch {
 	case errors.Is(err, ErrEmptyToken), errors.Is(err, ErrTokenTooLarge),
-		errors.Is(err, ErrEmptyRole), errors.Is(err, ErrRoleTooLarge),
-		errors.Is(err, ErrInvalidJSON):
+		errors.Is(err, ErrEmptyRole), errors.Is(err, ErrInvalidRoleFormat),
+		errors.Is(err, ErrRoleTooLarge), errors.Is(err, ErrInvalidJSON):
 		errCode = "invalid_request"
 		errMsg = "Invalid request parameters"
 		*statusCode = http.StatusBadRequest

--- a/internal/handler/lambdaurl.go
+++ b/internal/handler/lambdaurl.go
@@ -23,9 +23,9 @@ type AwsLambdaUrl struct {
 }
 
 // NewAwsLambdaUrl creates a new Lambda URL handler
-func NewAwsLambdaUrl(provider *config.Provider, consumer aws.AwsConsumerInterface, validator validator.TokenValidatorInterface) *AwsLambdaUrl {
+func NewAwsLambdaUrl(provider *config.Provider, consumer aws.AwsConsumerInterface, extractor validator.ClaimsExtractorInterface) *AwsLambdaUrl {
 	return &AwsLambdaUrl{
-		processor: NewRequestProcessor(provider, consumer, validator),
+		processor: NewRequestProcessor(provider, consumer, extractor),
 	}
 }
 
@@ -53,8 +53,11 @@ func (h *AwsLambdaUrl) Handler(ctx context.Context, event events.LambdaFunctionU
 		return h.respondError(ctx, err, http.StatusBadRequest)
 	}
 
+	// Build extraction input from the parsed request token.
+	input := validator.ExtractionInput{Token: requestData.Token}
+
 	// Process the request using the request processor
-	credentials, err := h.processor.ProcessRequest(ctx, requestData, requestID, log)
+	credentials, err := h.processor.ProcessRequest(ctx, requestData, input, requestID, log)
 	if err != nil {
 		statusCode := http.StatusInternalServerError
 		switch {

--- a/internal/handler/lambdaurl.go
+++ b/internal/handler/lambdaurl.go
@@ -115,35 +115,8 @@ func (h *AwsLambdaUrl) respondError(ctx context.Context, err error, statusCode i
 		processingMS = time.Since(startTime).Milliseconds()
 	}
 
-	// Create structured error
-	errCode := "internal_error"
-	errMsg := "An internal error occurred"
-
-	// Map common errors to specific error codes and messages
-	switch {
-	case errors.Is(err, ErrEmptyToken), errors.Is(err, ErrTokenTooLarge),
-		errors.Is(err, ErrEmptyRole), errors.Is(err, ErrRoleTooLarge),
-		errors.Is(err, ErrInvalidJSON):
-		errCode = "invalid_request"
-		errMsg = "Invalid request parameters"
-		statusCode = http.StatusBadRequest
-	case errors.Is(err, ErrTokenValidationFailed):
-		errCode = "token_invalid"
-		errMsg = "Token validation failed"
-		statusCode = http.StatusUnauthorized
-	case errors.Is(err, ErrRoleNotPermitted), errors.Is(err, ErrAccountNotAllowed):
-		errCode = "permission_denied"
-		errMsg = "Permission denied for the requested operation"
-		statusCode = http.StatusForbidden
-	case errors.Is(err, ErrSessionPolicyAccess):
-		errCode = "policy_error"
-		errMsg = "Error accessing policy information"
-		statusCode = http.StatusInternalServerError
-	case errors.Is(err, ErrAssumeRoleFailed):
-		errCode = "assume_role_failed"
-		errMsg = "Failed to assume the requested role"
-		statusCode = http.StatusInternalServerError
-	}
+	// Map common errors to specific error codes and messages (shared classifier).
+	errCode, errMsg := classifyError(err, &statusCode)
 
 	// Log the error with context
 	slog.Error("Request error",

--- a/internal/handler/lambdaurl.go
+++ b/internal/handler/lambdaurl.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -59,16 +58,7 @@ func (h *AwsLambdaUrl) Handler(ctx context.Context, event events.LambdaFunctionU
 	// Process the request using the request processor
 	credentials, err := h.processor.ProcessRequest(ctx, requestData, input, requestID, log)
 	if err != nil {
-		statusCode := http.StatusInternalServerError
-		switch {
-		case errors.Is(err, ErrTokenValidationFailed):
-			statusCode = http.StatusUnauthorized
-		case errors.Is(err, ErrRoleNotPermitted), errors.Is(err, ErrAccountNotAllowed):
-			statusCode = http.StatusForbidden
-		case errors.Is(err, ErrSessionPolicyAccess), errors.Is(err, ErrAssumeRoleFailed):
-			statusCode = http.StatusInternalServerError
-		}
-		return h.respondError(ctx, err, statusCode)
+		return h.respondError(ctx, err, http.StatusInternalServerError)
 	}
 
 	return h.respondJSON(ctx, credentials)

--- a/internal/handler/processor.go
+++ b/internal/handler/processor.go
@@ -20,20 +20,20 @@ import (
 type RequestProcessor struct {
 	provider  *config.Provider
 	consumer  aws.AwsConsumerInterface
-	validator validator.TokenValidatorInterface
+	extractor validator.ClaimsExtractorInterface
 }
 
 // NewRequestProcessor creates a new instance of request processor
-func NewRequestProcessor(provider *config.Provider, consumer aws.AwsConsumerInterface, validator validator.TokenValidatorInterface) *RequestProcessor {
+func NewRequestProcessor(provider *config.Provider, consumer aws.AwsConsumerInterface, extractor validator.ClaimsExtractorInterface) *RequestProcessor {
 	return &RequestProcessor{
 		provider:  provider,
 		consumer:  consumer,
-		validator: validator,
+		extractor: extractor,
 	}
 }
 
 // ProcessRequest contains the main business logic for processing requests
-func (r *RequestProcessor) ProcessRequest(ctx context.Context, requestData *RequestData, requestID string, log *slog.Logger) (*types.Credentials, error) {
+func (r *RequestProcessor) ProcessRequest(ctx context.Context, requestData *RequestData, input validator.ExtractionInput, requestID string, log *slog.Logger) (*types.Credentials, error) {
 	startTime, _ := ctx.Value(StartTimeContextKey).(time.Time)
 
 	// Pick up any hot-reloaded configuration (no-op unless reload is enabled),
@@ -41,17 +41,24 @@ func (r *RequestProcessor) ProcessRequest(ctx context.Context, requestData *Requ
 	r.provider.MaybeRefresh(ctx)
 	cfg := r.provider.Get()
 
-	// Create a redacted token for logging (first 10 chars and last 10 chars)
-	redactedToken := utils.RedactToken(requestData.Token, 10, 10)
-	log.Debug("Validating token", slog.String("token", redactedToken))
+	log.Debug("Extracting claims", slog.String("mode", func() string {
+		if input.Token != "" {
+			return "self"
+		}
+		if len(input.AuthorizerClaims) > 0 {
+			return "apigw"
+		}
+		if input.ALBOIDCData != "" {
+			return "alb"
+		}
+		return "unknown"
+	}()))
 
-	// Validate the token and extract claims
-	claims, err := r.validator.Validate(requestData.Token)
+	// Extract claims via the configured extractor (self-validation or delegated mode).
+	// All extraction errors wrap ErrTokenValidationFailed so adapters map them to HTTP 401.
+	claims, err := r.extractor.Extract(ctx, input)
 	if err != nil {
-		log.Error("Token validation failed",
-			slog.String("error", err.Error()),
-			slog.String("token", redactedToken),
-		)
+		log.Error("Claims extraction failed", slog.String("error", err.Error()))
 		return nil, fmt.Errorf("%w: %w", ErrTokenValidationFailed, err)
 	}
 

--- a/internal/handler/processor.go
+++ b/internal/handler/processor.go
@@ -41,18 +41,20 @@ func (r *RequestProcessor) ProcessRequest(ctx context.Context, requestData *Requ
 	r.provider.MaybeRefresh(ctx)
 	cfg := r.provider.Get()
 
-	log.Debug("Extracting claims", slog.String("mode", func() string {
-		if input.Token != "" {
-			return "self"
+	if log.Enabled(ctx, slog.LevelDebug) {
+		var mode string
+		switch {
+		case input.Token != "":
+			mode = "self"
+		case len(input.AuthorizerClaims) > 0:
+			mode = "apigw"
+		case input.ALBOIDCData != "":
+			mode = "alb"
+		default:
+			mode = "unknown"
 		}
-		if len(input.AuthorizerClaims) > 0 {
-			return "apigw"
-		}
-		if input.ALBOIDCData != "" {
-			return "alb"
-		}
-		return "unknown"
-	}()))
+		log.Debug("Extracting claims", slog.String("mode", mode))
+	}
 
 	// Extract claims via the configured extractor (self-validation or delegated mode).
 	// All extraction errors wrap ErrTokenValidationFailed so adapters map them to HTTP 401.

--- a/internal/handler/processor.go
+++ b/internal/handler/processor.go
@@ -93,16 +93,21 @@ func (r *RequestProcessor) ProcessRequest(ctx context.Context, requestData *Requ
 
 	// Convert claims to map for constraint checking
 	claimsMap := make(map[string]any)
-	claimsJSON, _ := json.Marshal(claims)
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		log.Error("Failed to marshal claims", slog.String("error", err.Error()))
+		return nil, fmt.Errorf("failed to marshal claims: %w", err)
+	}
 	if err := json.Unmarshal(claimsJSON, &claimsMap); err != nil {
 		log.Error("Failed to process claims", slog.String("error", err.Error()))
 		return nil, fmt.Errorf("failed to process claims: %w", err)
 	}
 
+	// Concise success line at Info; full claims only at Debug to keep audit-log volume down.
 	log.Info("Token validation successful",
-		slog.Any("claims", claims),
 		slog.Duration("validationTime", time.Since(startTime)),
 	)
+	log.Debug("Validated claims", slog.Any("claims", claims))
 
 	// Match role to repository with explicit constraints
 	matched, roles := cfg.MatchRolesToRepoWithConstraints(claims.Repository, claimsMap)

--- a/internal/handler/processor_auth_test.go
+++ b/internal/handler/processor_auth_test.go
@@ -9,18 +9,17 @@ import (
 	"github.com/boogy/aws-oidc-warden/internal/config"
 	"github.com/boogy/aws-oidc-warden/internal/handler"
 	"github.com/boogy/aws-oidc-warden/internal/types"
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/boogy/aws-oidc-warden/internal/validator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// stubValidator always returns an error to simulate JWT validation failure.
-type stubValidator struct{ err error }
+// stubExtractor always returns an error to simulate extraction failure.
+type stubExtractor struct{ err error }
 
-func (s *stubValidator) Validate(string) (*types.GithubClaims, error)   { return nil, s.err }
-func (s *stubValidator) ParseToken(string) (*types.GithubClaims, error) { return nil, s.err }
-func (s *stubValidator) FetchJWKS(string) (*types.JWKS, error)          { return nil, nil }
-func (s *stubValidator) GenKeyFunc(*types.JWKS) jwt.Keyfunc             { return nil }
+func (s *stubExtractor) Extract(_ context.Context, _ validator.ExtractionInput) (*types.GithubClaims, error) {
+	return nil, s.err
+}
 
 func TestProcessRequest_TokenValidationErrorIsSentinel(t *testing.T) {
 	cfg := &config.Config{
@@ -32,12 +31,13 @@ func TestProcessRequest_TokenValidationErrorIsSentinel(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 
 	provider := config.NewStaticProvider(cfg)
-	v := &stubValidator{err: errors.New("token is expired")}
-	proc := handler.NewRequestProcessor(provider, nil, v)
+	ex := &stubExtractor{err: errors.New("token is expired")}
+	proc := handler.NewRequestProcessor(provider, nil, ex)
 
 	_, err := proc.ProcessRequest(
 		context.Background(),
 		&handler.RequestData{Token: "t", Role: "r"},
+		validator.ExtractionInput{Token: "t"},
 		"req-id",
 		slog.Default(),
 	)

--- a/internal/handler/processor_tagauth_test.go
+++ b/internal/handler/processor_tagauth_test.go
@@ -14,17 +14,16 @@ import (
 	"github.com/boogy/aws-oidc-warden/internal/config"
 	"github.com/boogy/aws-oidc-warden/internal/handler"
 	"github.com/boogy/aws-oidc-warden/internal/types"
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/boogy/aws-oidc-warden/internal/validator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type tagModeValidator struct{ claims *types.GithubClaims }
+type tagModeExtractor struct{ claims *types.GithubClaims }
 
-func (v *tagModeValidator) Validate(string) (*types.GithubClaims, error)   { return v.claims, nil }
-func (v *tagModeValidator) ParseToken(string) (*types.GithubClaims, error) { return v.claims, nil }
-func (v *tagModeValidator) FetchJWKS(string) (*types.JWKS, error)          { return nil, nil }
-func (v *tagModeValidator) GenKeyFunc(*types.JWKS) jwt.Keyfunc             { return nil }
+func (e *tagModeExtractor) Extract(_ context.Context, _ validator.ExtractionInput) (*types.GithubClaims, error) {
+	return e.claims, nil
+}
 
 type fakeConsumer struct {
 	tags            map[string]string
@@ -72,9 +71,11 @@ func TestProcessRequest_TagAuthAllows(t *testing.T) {
 		assumeOut:    &ststypes.Credentials{AccessKeyId: aws.String("AK"), SecretAccessKey: aws.String("SK"), SessionToken: aws.String("ST"), Expiration: &exp},
 		allowAccount: true,
 	}
-	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeValidator{claims})
+	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeExtractor{claims})
 	creds, err := proc.ProcessRequest(context.Background(),
-		&handler.RequestData{Token: "t", Role: "arn:aws:iam::111111111111:role/app"}, "rid", slog.Default())
+		&handler.RequestData{Token: "t", Role: "arn:aws:iam::111111111111:role/app"},
+		validator.ExtractionInput{Token: "t"},
+		"rid", slog.Default())
 	require.NoError(t, err)
 	assert.Equal(t, "AK", *creds.AccessKeyId)
 	assert.Equal(t, "arn:aws:iam::111111111111:role/app", fc.assumed)
@@ -87,9 +88,11 @@ func TestProcessRequest_TagAuthDenies(t *testing.T) {
 	cfg := baseTagCfg(t)
 	claims := &types.GithubClaims{Repository: "acme/api", RepositoryOwner: "acme", Ref: "refs/heads/main"}
 	fc := &fakeConsumer{tags: map[string]string{"aow/repo": "acme/other"}, allowAccount: true}
-	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeValidator{claims})
+	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeExtractor{claims})
 	_, err := proc.ProcessRequest(context.Background(),
-		&handler.RequestData{Token: "t", Role: "arn:aws:iam::111111111111:role/app"}, "rid", slog.Default())
+		&handler.RequestData{Token: "t", Role: "arn:aws:iam::111111111111:role/app"},
+		validator.ExtractionInput{Token: "t"},
+		"rid", slog.Default())
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, handler.ErrRoleNotPermitted))
 }
@@ -123,9 +126,11 @@ func TestProcessRequest_TagAuthOverridesFailedMapping(t *testing.T) {
 		assumeOut:    &ststypes.Credentials{AccessKeyId: aws.String("AK"), SecretAccessKey: aws.String("SK"), SessionToken: aws.String("ST"), Expiration: &exp},
 		allowAccount: true,
 	}
-	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeValidator{claims})
+	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeExtractor{claims})
 	creds, err := proc.ProcessRequest(context.Background(),
-		&handler.RequestData{Token: "t", Role: "arn:aws:iam::111111111111:role/app"}, "rid", slog.Default())
+		&handler.RequestData{Token: "t", Role: "arn:aws:iam::111111111111:role/app"},
+		validator.ExtractionInput{Token: "t"},
+		"rid", slog.Default())
 	require.NoError(t, err, "tag-auth should authorize despite the failed mapping constraint")
 	assert.Equal(t, "AK", *creds.AccessKeyId)
 }
@@ -135,9 +140,11 @@ func TestProcessRequest_AccountNotAllowed(t *testing.T) {
 	claims := &types.GithubClaims{Repository: "acme/api", RepositoryOwner: "acme", Ref: "refs/heads/main"}
 	// allowAccount defaults to false → target account is denied.
 	fc := &fakeConsumer{tags: map[string]string{"aow/repo": "acme/api"}}
-	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeValidator{claims})
+	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeExtractor{claims})
 	_, err := proc.ProcessRequest(context.Background(),
-		&handler.RequestData{Token: "t", Role: "arn:aws:iam::999999999999:role/app"}, "rid", slog.Default())
+		&handler.RequestData{Token: "t", Role: "arn:aws:iam::999999999999:role/app"},
+		validator.ExtractionInput{Token: "t"},
+		"rid", slog.Default())
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, handler.ErrAccountNotAllowed))
 }
@@ -148,9 +155,11 @@ func TestProcessRequest_AccountCheckError(t *testing.T) {
 	// Infra error must take precedence over the allow/deny bool and map to a 5xx
 	// (ErrAssumeRoleFailed), never a 403 (ErrAccountNotAllowed).
 	fc := &fakeConsumer{tags: map[string]string{"aow/repo": "acme/api"}, allowAccount: true, allowAccountErr: errors.New("infra fail")}
-	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeValidator{claims})
+	proc := handler.NewRequestProcessor(config.NewStaticProvider(cfg), fc, &tagModeExtractor{claims})
 	_, err := proc.ProcessRequest(context.Background(),
-		&handler.RequestData{Token: "t", Role: "arn:aws:iam::999999999999:role/app"}, "rid", slog.Default())
+		&handler.RequestData{Token: "t", Role: "arn:aws:iam::999999999999:role/app"},
+		validator.ExtractionInput{Token: "t"},
+		"rid", slog.Default())
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, handler.ErrAssumeRoleFailed))
 	assert.False(t, errors.Is(err, handler.ErrAccountNotAllowed))

--- a/internal/handler/processor_test.go
+++ b/internal/handler/processor_test.go
@@ -1,0 +1,75 @@
+package handler_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/boogy/aws-oidc-warden/internal/config"
+	"github.com/boogy/aws-oidc-warden/internal/handler"
+	"github.com/boogy/aws-oidc-warden/internal/types"
+	"github.com/boogy/aws-oidc-warden/internal/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedExtractor returns a fixed set of claims without touching any token.
+type fixedExtractor struct{ claims *types.GithubClaims }
+
+func (f *fixedExtractor) Extract(_ context.Context, _ validator.ExtractionInput) (*types.GithubClaims, error) {
+	return f.claims, nil
+}
+
+// staticProvider builds a config.Provider that maps "org/repo" → "arn:aws:iam::123456789012:role/MyRole".
+func staticProvider(t *testing.T) *config.Provider {
+	t.Helper()
+	cfg := &config.Config{
+		Issuer:          "https://token.actions.githubusercontent.com",
+		Audiences:       []string{"sts.amazonaws.com"},
+		RoleSessionName: "test",
+		Cache:           &config.Cache{TTL: 0},
+		RepoRoleMappings: []config.RepoRoleMapping{{
+			Repo:  "org/repo",
+			Roles: []string{"arn:aws:iam::123456789012:role/MyRole"},
+		}},
+	}
+	require.NoError(t, cfg.Validate())
+	return config.NewStaticProvider(cfg)
+}
+
+// mockConsumer returns a fakeConsumer that successfully assumes any role.
+func mockConsumer(t *testing.T) *fakeConsumer {
+	t.Helper()
+	exp := time.Now().Add(time.Hour)
+	return &fakeConsumer{
+		assumeOut: &ststypes.Credentials{
+			AccessKeyId:     aws.String("AKID"),
+			SecretAccessKey: aws.String("SECRET"),
+			SessionToken:    aws.String("TOKEN"),
+			Expiration:      &exp,
+		},
+		allowAccount: true,
+	}
+}
+
+func TestProcessRequest_DelegatedMode(t *testing.T) {
+	// extractor returns fixed claims without touching a token (delegated/apigw mode)
+	ex := &fixedExtractor{claims: &types.GithubClaims{
+		Repository: "org/repo",
+		Ref:        "refs/heads/main",
+		Actor:      "octocat",
+	}}
+	proc := handler.NewRequestProcessor(staticProvider(t), mockConsumer(t), ex)
+	creds, err := proc.ProcessRequest(
+		context.Background(),
+		&handler.RequestData{Role: "arn:aws:iam::123456789012:role/MyRole"},
+		validator.ExtractionInput{AuthorizerClaims: map[string]string{"repository": "org/repo"}},
+		"req-123",
+		slog.Default(),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, creds)
+}

--- a/internal/handler/types.go
+++ b/internal/handler/types.go
@@ -32,6 +32,7 @@ var (
 	ErrEmptyToken            = errors.New("token is empty")
 	ErrTokenTooLarge         = errors.New("token exceeds maximum allowed size")
 	ErrEmptyRole             = errors.New("role is empty")
+	ErrInvalidRoleFormat     = errors.New("role is not a valid AWS IAM role ARN")
 	ErrRoleTooLarge          = errors.New("role exceeds maximum allowed size")
 	ErrInvalidJSON           = errors.New("invalid JSON in request body")
 	ErrTokenValidationFailed = errors.New("token validation failed")

--- a/internal/handler/validation.go
+++ b/internal/handler/validation.go
@@ -9,41 +9,53 @@ import (
 	"github.com/boogy/aws-oidc-warden/internal/utils"
 )
 
-// ValidateRequestData validates common request data fields
-func ValidateRequestData(token, role string) error {
-	// Validate token is not empty
-	if strings.TrimSpace(token) == "" {
-		return ErrEmptyToken
-	}
-
-	// Check token length for security (prevent DoS)
-	if len(token) > MaxTokenLength {
-		return ErrTokenTooLarge
-	}
-
-	// Validate role
+// validateRole validates that a role ARN is non-empty, within size bounds, and
+// has a recognized AWS partition prefix. Extracted for reuse by both
+// ValidateRequestData and ParseRoleOnlyRequestBody.
+func validateRole(role string) error {
 	if strings.TrimSpace(role) == "" {
 		return ErrEmptyRole
 	}
-
-	// Check role length for security
 	if len(role) > MaxRoleLength {
 		return ErrRoleTooLarge
 	}
-
-	isValidPrefix := false
 	for _, prefix := range ValidPrefixes {
 		if strings.HasPrefix(role, prefix) {
-			isValidPrefix = true
-			break
+			return nil
 		}
 	}
+	return fmt.Errorf("role does not appear to be a valid AWS IAM role ARN: %w", ErrEmptyRole)
+}
 
-	if !isValidPrefix {
-		return fmt.Errorf("role does not appear to be a valid AWS IAM role ARN: %w", ErrEmptyRole)
+// ValidateRequestData validates common request data fields
+func ValidateRequestData(token, role string) error {
+	if strings.TrimSpace(token) == "" {
+		return ErrEmptyToken
 	}
+	if len(token) > MaxTokenLength {
+		return ErrTokenTooLarge
+	}
+	return validateRole(role)
+}
 
-	return nil
+// ParseRoleOnlyRequestBody parses and validates a delegated-mode request body.
+// In delegated mode the JWT is validated by an upstream service; only the role
+// ARN must be present in the request body.
+func ParseRoleOnlyRequestBody(body string) (*RequestData, error) {
+	if strings.TrimSpace(body) == "" {
+		return nil, fmt.Errorf("request body is empty: %w", ErrInvalidJSON)
+	}
+	if len(body) > 1024*1024 {
+		return nil, fmt.Errorf("request body too large: %w", ErrInvalidJSON)
+	}
+	var data RequestData
+	if err := json.Unmarshal([]byte(body), &data); err != nil {
+		return nil, fmt.Errorf("invalid JSON format: %w", ErrInvalidJSON)
+	}
+	if err := validateRole(data.Role); err != nil {
+		return nil, err
+	}
+	return &data, nil
 }
 
 // ParseRequestBody parses and validates JSON request body into RequestData

--- a/internal/handler/validation.go
+++ b/internal/handler/validation.go
@@ -9,6 +9,8 @@ import (
 	"github.com/boogy/aws-oidc-warden/internal/utils"
 )
 
+const maxBodyBytes = 1024 * 1024
+
 // validateRole validates that a role ARN is non-empty, within size bounds, and
 // has a recognized AWS partition prefix. Extracted for reuse by both
 // ValidateRequestData and ParseRoleOnlyRequestBody.
@@ -45,7 +47,7 @@ func ParseRoleOnlyRequestBody(body string) (*RequestData, error) {
 	if strings.TrimSpace(body) == "" {
 		return nil, fmt.Errorf("request body is empty: %w", ErrInvalidJSON)
 	}
-	if len(body) > 1024*1024 {
+	if len(body) > maxBodyBytes {
 		return nil, fmt.Errorf("request body too large: %w", ErrInvalidJSON)
 	}
 	var data RequestData
@@ -66,7 +68,7 @@ func ParseRequestBody(body string) (*RequestData, error) {
 	}
 
 	// Check if body exceeds maximum allowed size (sanity check)
-	if len(body) > 1024*1024 { // 1MB limit
+	if len(body) > maxBodyBytes { // 1MB limit
 		return nil, fmt.Errorf("request body too large: %w", ErrInvalidJSON)
 	}
 

--- a/internal/handler/validation.go
+++ b/internal/handler/validation.go
@@ -24,7 +24,7 @@ func validateRole(role string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("role does not appear to be a valid AWS IAM role ARN: %w", ErrEmptyRole)
+	return fmt.Errorf("role %q does not have a recognized AWS partition prefix: %w", role, ErrInvalidRoleFormat)
 }
 
 // ValidateRequestData validates common request data fields

--- a/internal/validator/CLAUDE.md
+++ b/internal/validator/CLAUDE.md
@@ -28,3 +28,30 @@ Flow: parse header → fetch JWKS (cached) → verify signature → validate iss
 - Token `kid` must match a JWKS key.
 
 Tests: `validator_test.go`, `multi_audience_test.go`, `integration_test.go` (mock JWKS server + generated JWTs).
+
+## Extractors
+
+`ClaimsExtractorInterface` abstracts how GitHub OIDC claims enter the pipeline:
+
+```go
+type ClaimsExtractorInterface interface {
+    Extract(ctx context.Context, input ExtractionInput) (*types.GithubClaims, error)
+}
+```
+
+Populate only the `ExtractionInput` fields relevant to the configured mode:
+
+| Field              | Used by        |
+| ------------------ | -------------- |
+| `Token`            | SelfExtractor  |
+| `AuthorizerClaims` | APIGWExtractor |
+| `ALBOIDCData`      | ALBExtractor   |
+| `AWSRegion`        | ALBExtractor   |
+
+**Implementations:**
+
+- `SelfExtractor` — default; wraps `TokenValidatorInterface.Validate()`. Full JWKS signature + claims verification.
+- `APIGWExtractor` — reads pre-validated `map[string]string` claims from API Gateway HTTP API v2 JWT Authorizer. Rejects if `AuthorizerClaims` is nil (bypass guard). No signature verification.
+- `ALBExtractor` — fetches ALB EC public key via HTTPS, verifies ES256 JWT from `x-amzn-oidc-data`. Validates optional `ALBExpectedSigner` ARN. Use `WithALBKeyEndpoint` to override in tests. Caches keys for 5 minutes to avoid per-request latency.
+
+The factory `newClaimsExtractor(mode, albExpectedSigner, validator)` in `bootstrap.go` selects the implementation from `cfg.JWTValidation.Mode`.

--- a/internal/validator/alb_extractor.go
+++ b/internal/validator/alb_extractor.go
@@ -1,0 +1,217 @@
+package validator
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/boogy/aws-oidc-warden/internal/types"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const defaultALBKeyEndpoint = "https://public-keys.auth.elb.%s.amazonaws.com/%s"
+
+// ALBExtractor verifies the ALB-signed x-amzn-oidc-data JWT (ES256) and
+// extracts GitHub OIDC claims. If expectedSigner is non-empty, the JWT
+// header's "signer" field must match exactly (prevents cross-ALB injection).
+// Defense-in-depth: re-validates issuer and audience after signature verification.
+type ALBExtractor struct {
+	expectedSigner    string
+	expectedIssuer    string
+	expectedAudiences []string
+	keyEndpointFmt    string // format string with two %s: region, kid
+	httpClient        *http.Client
+}
+
+// ALBOption configures ALBExtractor (functional option pattern).
+type ALBOption func(*ALBExtractor)
+
+// WithALBKeyEndpoint overrides the public key URL format (for testing).
+// The format string receives one %s: the kid.
+func WithALBKeyEndpoint(fmtURL string) ALBOption {
+	return func(a *ALBExtractor) { a.keyEndpointFmt = fmtURL }
+}
+
+// NewALBExtractor creates an ALBExtractor.
+// expectedSigner: ALB ARN that must match the JWT "signer" header (empty disables the check).
+// expectedIssuer / expectedAudiences: validated after signature verification for defense in depth.
+func NewALBExtractor(expectedSigner, expectedIssuer string, expectedAudiences []string, opts ...ALBOption) *ALBExtractor {
+	a := &ALBExtractor{
+		expectedSigner:    expectedSigner,
+		expectedIssuer:    expectedIssuer,
+		expectedAudiences: expectedAudiences,
+		keyEndpointFmt:    defaultALBKeyEndpoint,
+		httpClient:        &http.Client{Timeout: 5 * time.Second},
+	}
+	for _, o := range opts {
+		o(a)
+	}
+	return a
+}
+
+// isValidALBKid rejects kid values that could manipulate the key endpoint URL.
+// Only URL-safe alphanumeric, hyphen, and underscore are permitted (max 128 chars).
+func isValidALBKid(kid string) bool {
+	if len(kid) == 0 || len(kid) > 128 {
+		return false
+	}
+	for _, r := range kid {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-' && r != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+// Extract verifies the ALB-signed JWT and returns the embedded OIDC claims.
+func (a *ALBExtractor) Extract(ctx context.Context, input ExtractionInput) (*types.GithubClaims, error) {
+	if input.ALBOIDCData == "" {
+		return nil, fmt.Errorf("x-amzn-oidc-data header is absent: request may have bypassed ALB OIDC")
+	}
+
+	// Parse without verification to extract kid and signer from header.
+	unverified, _, err := jwt.NewParser().ParseUnverified(input.ALBOIDCData, jwt.MapClaims{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ALB OIDC JWT: %w", err)
+	}
+
+	kid, _ := unverified.Header["kid"].(string)
+	// Validate kid before using it in a URL — prevents SSRF via path traversal or
+	// URL injection in the key endpoint format string.
+	if !isValidALBKid(kid) {
+		return nil, fmt.Errorf("ALB JWT kid contains invalid characters: %q", kid)
+	}
+
+	signer, _ := unverified.Header["signer"].(string)
+	if a.expectedSigner != "" && signer != a.expectedSigner {
+		return nil, fmt.Errorf("ALB JWT signer mismatch: got %q, want %q", signer, a.expectedSigner)
+	}
+
+	// Fetch ALB public key.
+	ecKey, err := a.fetchPublicKey(ctx, input.AWSRegion, kid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch ALB public key: %w", err)
+	}
+
+	// Verify JWT with the EC key; ES256 enforced via WithValidMethods.
+	token, err := jwt.ParseWithClaims(
+		input.ALBOIDCData,
+		jwt.MapClaims{},
+		func(t *jwt.Token) (any, error) { return ecKey, nil },
+		jwt.WithValidMethods([]string{"ES256"}),
+	)
+	if err != nil || !token.Valid {
+		return nil, fmt.Errorf("ALB OIDC JWT verification failed: %w", err)
+	}
+
+	mc, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("unexpected ALB JWT claims type")
+	}
+	return a.mapALBClaims(mc)
+}
+
+func (a *ALBExtractor) fetchPublicKey(ctx context.Context, region, kid string) (*ecdsa.PublicKey, error) {
+	if region == "" && strings.Count(a.keyEndpointFmt, "%s") == 2 {
+		return nil, fmt.Errorf("AWSRegion is required for ALB public key lookup; set AWS_REGION env var")
+	}
+
+	var url string
+	if strings.Count(a.keyEndpointFmt, "%s") == 2 {
+		url = fmt.Sprintf(a.keyEndpointFmt, region, kid)
+	} else {
+		// test override with single %s (just kid)
+		url = fmt.Sprintf(a.keyEndpointFmt, kid)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			slog.Error("failed to close ALB key endpoint response body", "error", cerr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ALB key endpoint returned HTTP %d for kid %q", resp.StatusCode, kid)
+	}
+
+	pemBytes, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block from ALB key endpoint")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ALB public key: %w", err)
+	}
+	ecKey, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("ALB public key is not an EC key")
+	}
+	// Enforce P-256 — ES256 requires P-256; other curves cause unexpected behaviour.
+	if ecKey.Curve != elliptic.P256() {
+		return nil, fmt.Errorf("ALB public key uses unexpected curve %s, expected P-256", ecKey.Curve.Params().Name)
+	}
+	return ecKey, nil
+}
+
+func (a *ALBExtractor) mapALBClaims(mc jwt.MapClaims) (*types.GithubClaims, error) {
+	// Convert MapClaims to map[string]string for reuse with mapAPIGWClaims.
+	// jwt.MapClaims stores numeric values as float64; use FormatInt to avoid
+	// scientific notation (e.g. "1.75e+09") that breaks ParseInt.
+	raw := make(map[string]string, len(mc))
+	for k, v := range mc {
+		switch val := v.(type) {
+		case string:
+			raw[k] = val
+		case float64:
+			raw[k] = strconv.FormatInt(int64(val), 10)
+		default:
+			raw[k] = fmt.Sprintf("%v", val)
+		}
+	}
+
+	// Defense-in-depth: re-validate issuer and audience after signature verification.
+	// Guards against an ALB misconfigured with a different OIDC provider.
+	iss := raw["iss"]
+	if iss != a.expectedIssuer {
+		return nil, fmt.Errorf("ALB JWT iss mismatch: got %q, want %q", iss, a.expectedIssuer)
+	}
+	aud := raw["aud"]
+	matched := false
+	for _, want := range a.expectedAudiences {
+		if aud == want {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil, fmt.Errorf("ALB JWT aud mismatch: got %q, not in allowed set %v", aud, a.expectedAudiences)
+	}
+
+	return (&APIGWExtractor{
+		expectedIssuer:    a.expectedIssuer,
+		expectedAudiences: a.expectedAudiences,
+	}).mapAPIGWClaims(raw)
+}

--- a/internal/validator/alb_extractor.go
+++ b/internal/validator/alb_extractor.go
@@ -42,10 +42,11 @@ type albKeyCacheEntry struct {
 const albKeyCacheTTL = 5 * time.Minute
 
 func (c *albKeyCache) get(kid string) (*ecdsa.PublicKey, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	e, ok := c.entries[kid]
 	if !ok || time.Now().After(e.expiresAt) {
+		delete(c.entries, kid)
 		return nil, false
 	}
 	return e.key, true
@@ -68,7 +69,8 @@ type ALBExtractor struct {
 	expectedSigner    string
 	expectedIssuer    string
 	expectedAudiences []string
-	keyEndpointFmt    string // format string with two %s: region, kid
+	keyEndpointFmt    string // format string for the public key URL
+	testEndpoint      bool   // true when keyEndpointFmt uses a single %s (test override)
 	httpClient        *http.Client
 	keyCache          albKeyCache
 }
@@ -96,6 +98,7 @@ func NewALBExtractor(expectedSigner, expectedIssuer string, expectedAudiences []
 	for _, o := range opts {
 		o(a)
 	}
+	a.testEndpoint = strings.Count(a.keyEndpointFmt, "%s") == 1
 	return a
 }
 
@@ -169,8 +172,7 @@ func (a *ALBExtractor) fetchPublicKey(ctx context.Context, region, kid string) (
 		return key, nil
 	}
 
-	placeholderCount := strings.Count(a.keyEndpointFmt, "%s")
-	if placeholderCount == 2 {
+	if !a.testEndpoint {
 		if region == "" {
 			return nil, fmt.Errorf("AWSRegion is required for ALB public key lookup; set AWS_REGION env var")
 		}
@@ -180,10 +182,9 @@ func (a *ALBExtractor) fetchPublicKey(ctx context.Context, region, kid string) (
 	}
 
 	var keyURL string
-	if placeholderCount == 2 {
+	if !a.testEndpoint {
 		keyURL = fmt.Sprintf(a.keyEndpointFmt, region, kid)
 	} else {
-		// test override with single %s (just kid)
 		keyURL = fmt.Sprintf(a.keyEndpointFmt, kid)
 	}
 
@@ -244,24 +245,6 @@ func (a *ALBExtractor) mapALBClaims(mc jwt.MapClaims) (*types.GithubClaims, erro
 		default:
 			raw[k] = fmt.Sprintf("%v", val)
 		}
-	}
-
-	// Defense-in-depth: re-validate issuer and audience after signature verification.
-	// Guards against an ALB misconfigured with a different OIDC provider.
-	iss := raw["iss"]
-	if iss != a.expectedIssuer {
-		return nil, fmt.Errorf("ALB JWT iss mismatch: got %q, want %q", iss, a.expectedIssuer)
-	}
-	aud := raw["aud"]
-	matched := false
-	for _, want := range a.expectedAudiences {
-		if aud == want {
-			matched = true
-			break
-		}
-	}
-	if !matched {
-		return nil, fmt.Errorf("ALB JWT aud mismatch: got %q, not in allowed set %v", aud, a.expectedAudiences)
 	}
 
 	return (&APIGWExtractor{

--- a/internal/validator/alb_extractor.go
+++ b/internal/validator/alb_extractor.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/boogy/aws-oidc-warden/internal/types"
@@ -19,6 +20,39 @@ import (
 )
 
 const defaultALBKeyEndpoint = "https://public-keys.auth.elb.%s.amazonaws.com/%s"
+
+// albKeyCache is a short-lived in-memory cache for ALB EC public keys, keyed by kid.
+// Avoids a per-request HTTPS round-trip to the AWS key endpoint.
+type albKeyCache struct {
+	mu      sync.RWMutex
+	entries map[string]albKeyCacheEntry
+}
+
+type albKeyCacheEntry struct {
+	key       *ecdsa.PublicKey
+	expiresAt time.Time
+}
+
+const albKeyCacheTTL = 5 * time.Minute
+
+func (c *albKeyCache) get(kid string) (*ecdsa.PublicKey, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[kid]
+	if !ok || time.Now().After(e.expiresAt) {
+		return nil, false
+	}
+	return e.key, true
+}
+
+func (c *albKeyCache) set(kid string, key *ecdsa.PublicKey) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.entries == nil {
+		c.entries = make(map[string]albKeyCacheEntry)
+	}
+	c.entries[kid] = albKeyCacheEntry{key: key, expiresAt: time.Now().Add(albKeyCacheTTL)}
+}
 
 // ALBExtractor verifies the ALB-signed x-amzn-oidc-data JWT (ES256) and
 // extracts GitHub OIDC claims. If expectedSigner is non-empty, the JWT
@@ -30,6 +64,7 @@ type ALBExtractor struct {
 	expectedAudiences []string
 	keyEndpointFmt    string // format string with two %s: region, kid
 	httpClient        *http.Client
+	keyCache          albKeyCache
 }
 
 // ALBOption configures ALBExtractor (functional option pattern).
@@ -121,6 +156,10 @@ func (a *ALBExtractor) Extract(ctx context.Context, input ExtractionInput) (*typ
 }
 
 func (a *ALBExtractor) fetchPublicKey(ctx context.Context, region, kid string) (*ecdsa.PublicKey, error) {
+	if key, ok := a.keyCache.get(kid); ok {
+		return key, nil
+	}
+
 	placeholderCount := strings.Count(a.keyEndpointFmt, "%s")
 	if region == "" && placeholderCount == 2 {
 		return nil, fmt.Errorf("AWSRegion is required for ALB public key lookup; set AWS_REGION env var")
@@ -173,6 +212,7 @@ func (a *ALBExtractor) fetchPublicKey(ctx context.Context, region, kid string) (
 	if ecKey.Curve != elliptic.P256() {
 		return nil, fmt.Errorf("ALB public key uses unexpected curve %s, expected P-256", ecKey.Curve.Params().Name)
 	}
+	a.keyCache.set(kid, ecKey)
 	return ecKey, nil
 }
 

--- a/internal/validator/alb_extractor.go
+++ b/internal/validator/alb_extractor.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +21,11 @@ import (
 )
 
 const defaultALBKeyEndpoint = "https://public-keys.auth.elb.%s.amazonaws.com/%s"
+
+// albRegionRe constrains AWS_REGION before it is interpolated into the key
+// endpoint URL. AWS_REGION is operator-set (trusted), so this is an explicit,
+// testable guard rather than a fix for an exploit.
+var albRegionRe = regexp.MustCompile(`^[a-z]{2}-[a-z]+-\d+$`)
 
 // albKeyCache is a short-lived in-memory cache for ALB EC public keys, keyed by kid.
 // Avoids a per-request HTTPS round-trip to the AWS key endpoint.
@@ -138,11 +144,14 @@ func (a *ALBExtractor) Extract(ctx context.Context, input ExtractionInput) (*typ
 	}
 
 	// Verify JWT with the EC key; ES256 enforced via WithValidMethods.
+	// Match self-mode strictness: require exp and validate iat at the library level.
 	token, err := jwt.ParseWithClaims(
 		input.ALBOIDCData,
 		jwt.MapClaims{},
 		func(t *jwt.Token) (any, error) { return ecKey, nil },
 		jwt.WithValidMethods([]string{"ES256"}),
+		jwt.WithExpirationRequired(),
+		jwt.WithIssuedAt(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("ALB OIDC JWT verification failed: %w", err)
@@ -161,8 +170,13 @@ func (a *ALBExtractor) fetchPublicKey(ctx context.Context, region, kid string) (
 	}
 
 	placeholderCount := strings.Count(a.keyEndpointFmt, "%s")
-	if region == "" && placeholderCount == 2 {
-		return nil, fmt.Errorf("AWSRegion is required for ALB public key lookup; set AWS_REGION env var")
+	if placeholderCount == 2 {
+		if region == "" {
+			return nil, fmt.Errorf("AWSRegion is required for ALB public key lookup; set AWS_REGION env var")
+		}
+		if !albRegionRe.MatchString(region) {
+			return nil, fmt.Errorf("AWSRegion %q is not a valid AWS region", region)
+		}
 	}
 
 	var keyURL string

--- a/internal/validator/alb_extractor.go
+++ b/internal/validator/alb_extractor.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/boogy/aws-oidc-warden/internal/types"
 	"github.com/golang-jwt/jwt/v5"
@@ -60,13 +59,13 @@ func NewALBExtractor(expectedSigner, expectedIssuer string, expectedAudiences []
 }
 
 // isValidALBKid rejects kid values that could manipulate the key endpoint URL.
-// Only URL-safe alphanumeric, hyphen, and underscore are permitted (max 128 chars).
+// Only ASCII alphanumeric, hyphen, and underscore are permitted (max 128 chars).
 func isValidALBKid(kid string) bool {
 	if len(kid) == 0 || len(kid) > 128 {
 		return false
 	}
 	for _, r := range kid {
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-' && r != '_' {
+		if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' && r != '_' {
 			return false
 		}
 	}
@@ -110,7 +109,7 @@ func (a *ALBExtractor) Extract(ctx context.Context, input ExtractionInput) (*typ
 		func(t *jwt.Token) (any, error) { return ecKey, nil },
 		jwt.WithValidMethods([]string{"ES256"}),
 	)
-	if err != nil || !token.Valid {
+	if err != nil {
 		return nil, fmt.Errorf("ALB OIDC JWT verification failed: %w", err)
 	}
 
@@ -122,19 +121,20 @@ func (a *ALBExtractor) Extract(ctx context.Context, input ExtractionInput) (*typ
 }
 
 func (a *ALBExtractor) fetchPublicKey(ctx context.Context, region, kid string) (*ecdsa.PublicKey, error) {
-	if region == "" && strings.Count(a.keyEndpointFmt, "%s") == 2 {
+	placeholderCount := strings.Count(a.keyEndpointFmt, "%s")
+	if region == "" && placeholderCount == 2 {
 		return nil, fmt.Errorf("AWSRegion is required for ALB public key lookup; set AWS_REGION env var")
 	}
 
-	var url string
-	if strings.Count(a.keyEndpointFmt, "%s") == 2 {
-		url = fmt.Sprintf(a.keyEndpointFmt, region, kid)
+	var keyURL string
+	if placeholderCount == 2 {
+		keyURL = fmt.Sprintf(a.keyEndpointFmt, region, kid)
 	} else {
 		// test override with single %s (just kid)
-		url = fmt.Sprintf(a.keyEndpointFmt, kid)
+		keyURL = fmt.Sprintf(a.keyEndpointFmt, kid)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, keyURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/validator/alb_extractor_test.go
+++ b/internal/validator/alb_extractor_test.go
@@ -125,3 +125,48 @@ func TestALBExtractor_IssuerMismatch(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "iss")
 }
+
+func TestALBExtractor_KeyCache(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	kid := "cache-test-kid"
+	pubDER, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		_, _ = w.Write(pubPEM)
+	}))
+	defer srv.Close()
+
+	token := makeALBJWT(t, priv, kid, "", map[string]any{
+		"iss": "https://token.actions.githubusercontent.com", "aud": "sts.amazonaws.com",
+		"repository": "org/repo",
+		"exp":        time.Now().Add(time.Hour).Unix(),
+	})
+
+	ex := validator.NewALBExtractor("", "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"}, validator.WithALBKeyEndpoint(srv.URL+"/%s"))
+	input := validator.ExtractionInput{ALBOIDCData: token, AWSRegion: "us-east-1"}
+
+	_, err := ex.Extract(context.Background(), input)
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+
+	// Second call must use cache, not hit HTTP again.
+	_, err = ex.Extract(context.Background(), input)
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount, "expected cache hit; key endpoint called again")
+}
+
+func TestALBExtractor_MissingRegion(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	token := makeALBJWT(t, priv, "valid-kid", "", map[string]any{
+		"iss": "https://token.actions.githubusercontent.com", "aud": "sts.amazonaws.com",
+		"repository": "org/repo",
+		"exp":        time.Now().Add(time.Hour).Unix(),
+	})
+	ex := validator.NewALBExtractor("", "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{ALBOIDCData: token, AWSRegion: ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AWSRegion")
+}

--- a/internal/validator/alb_extractor_test.go
+++ b/internal/validator/alb_extractor_test.go
@@ -1,0 +1,127 @@
+package validator_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/boogy/aws-oidc-warden/internal/validator"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeALBJWT(t *testing.T, key *ecdsa.PrivateKey, kid, signer string, claims map[string]any) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims(claims))
+	tok.Header["kid"] = kid
+	tok.Header["signer"] = signer
+	signed, err := tok.SignedString(key)
+	require.NoError(t, err)
+	return signed
+}
+
+func TestALBExtractor_Extract(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	kid := "test-kid-123"
+	alb := "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc"
+
+	pubDER, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	// Mock key endpoint
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(pubPEM)
+	}))
+	defer srv.Close()
+
+	token := makeALBJWT(t, priv, kid, alb, map[string]any{
+		"iss":        "https://token.actions.githubusercontent.com",
+		"sub":        "repo:org/repo:ref:refs/heads/main",
+		"aud":        "sts.amazonaws.com",
+		"exp":        time.Now().Add(time.Hour).Unix(),
+		"iat":        time.Now().Unix(),
+		"repository": "org/repo",
+		"ref":        "refs/heads/main",
+		"ref_type":   "branch",
+		"actor":      "octocat",
+	})
+
+	ex := validator.NewALBExtractor("", "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"}, validator.WithALBKeyEndpoint(srv.URL+"/%s"))
+	claims, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		ALBOIDCData: token,
+		AWSRegion:   "us-east-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "org/repo", claims.Repository)
+	assert.Equal(t, "octocat", claims.Actor)
+}
+
+func TestALBExtractor_MissingHeader(t *testing.T) {
+	ex := validator.NewALBExtractor("", "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{ALBOIDCData: ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "x-amzn-oidc-data")
+}
+
+func TestALBExtractor_WrongSigner(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	kid := "test-kid-456"
+	alb := "arn:aws:elasticloadbalancing:us-east-1:999:loadbalancer/app/evil/xyz"
+
+	pubDER, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(pubPEM) }))
+	defer srv.Close()
+
+	token := makeALBJWT(t, priv, kid, alb, map[string]any{
+		"iss": "https://token.actions.githubusercontent.com", "aud": "sts.amazonaws.com",
+		"repository": "org/repo", "exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	expected := "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc"
+	ex := validator.NewALBExtractor(expected, "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"}, validator.WithALBKeyEndpoint(srv.URL+"/%s"))
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		ALBOIDCData: token, AWSRegion: "us-east-1",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signer")
+}
+
+func TestALBExtractor_MaliciousKID(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	for _, badKid := range []string{"../../etc/passwd", "?redirect=http://evil", "http://attacker.com/key", " ", ""} {
+		token := makeALBJWT(t, priv, badKid, "", map[string]any{
+			"repository": "org/repo", "exp": time.Now().Add(time.Hour).Unix(),
+		})
+		ex := validator.NewALBExtractor("", "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+		_, err := ex.Extract(context.Background(), validator.ExtractionInput{ALBOIDCData: token, AWSRegion: "us-east-1"})
+		require.Errorf(t, err, "expected error for kid=%q", badKid)
+		assert.Contains(t, err.Error(), "kid")
+	}
+}
+
+func TestALBExtractor_IssuerMismatch(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	kid := "test-kid-iss"
+	pubDER, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(pubPEM) }))
+	defer srv.Close()
+
+	token := makeALBJWT(t, priv, kid, "", map[string]any{
+		"iss": "https://evil.example.com", "aud": "sts.amazonaws.com",
+		"repository": "org/repo", "exp": time.Now().Add(time.Hour).Unix(),
+	})
+	ex := validator.NewALBExtractor("", "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"}, validator.WithALBKeyEndpoint(srv.URL+"/%s"))
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{ALBOIDCData: token, AWSRegion: "us-east-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "iss")
+}

--- a/internal/validator/alb_extractor_test.go
+++ b/internal/validator/alb_extractor_test.go
@@ -158,6 +158,63 @@ func TestALBExtractor_KeyCache(t *testing.T) {
 	assert.Equal(t, 1, callCount, "expected cache hit; key endpoint called again")
 }
 
+func TestALBExtractor_ExpiredToken(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	kid := "test-kid-expired"
+	pubDER, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(pubPEM) }))
+	defer srv.Close()
+
+	token := makeALBJWT(t, priv, kid, "", map[string]any{
+		"iss": "https://token.actions.githubusercontent.com", "aud": "sts.amazonaws.com",
+		"repository": "org/repo",
+		"exp":        time.Now().Add(-time.Hour).Unix(),
+		"iat":        time.Now().Add(-2 * time.Hour).Unix(),
+	})
+	ex := validator.NewALBExtractor("", "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"}, validator.WithALBKeyEndpoint(srv.URL+"/%s"))
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{ALBOIDCData: token, AWSRegion: "us-east-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestALBExtractor_MissingExp(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	kid := "test-kid-noexp"
+	pubDER, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(pubPEM) }))
+	defer srv.Close()
+
+	// No exp claim — WithExpirationRequired() must reject at the library level.
+	token := makeALBJWT(t, priv, kid, "", map[string]any{
+		"iss": "https://token.actions.githubusercontent.com", "aud": "sts.amazonaws.com",
+		"repository": "org/repo",
+	})
+	ex := validator.NewALBExtractor("", "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"}, validator.WithALBKeyEndpoint(srv.URL+"/%s"))
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{ALBOIDCData: token, AWSRegion: "us-east-1"})
+	require.Error(t, err)
+}
+
+func TestALBExtractor_FutureIssuedAt(t *testing.T) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	kid := "test-kid-futureiat"
+	pubDER, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(pubPEM) }))
+	defer srv.Close()
+
+	token := makeALBJWT(t, priv, kid, "", map[string]any{
+		"iss": "https://token.actions.githubusercontent.com", "aud": "sts.amazonaws.com",
+		"repository": "org/repo",
+		"exp":        time.Now().Add(2 * time.Hour).Unix(),
+		"iat":        time.Now().Add(time.Hour).Unix(),
+	})
+	ex := validator.NewALBExtractor("", "https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"}, validator.WithALBKeyEndpoint(srv.URL+"/%s"))
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{ALBOIDCData: token, AWSRegion: "us-east-1"})
+	require.Error(t, err)
+}
+
 func TestALBExtractor_MissingRegion(t *testing.T) {
 	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	token := makeALBJWT(t, priv, "valid-kid", "", map[string]any{

--- a/internal/validator/apigw_extractor.go
+++ b/internal/validator/apigw_extractor.go
@@ -1,0 +1,113 @@
+package validator
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/boogy/aws-oidc-warden/internal/types"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// APIGWExtractor reads pre-validated claims from the API Gateway HTTP API v2
+// JWT Authorizer context (event.requestContext.authorizer.jwt.claims).
+// It does NOT verify signatures — that responsibility belongs to API Gateway.
+// If AuthorizerClaims is nil or empty, it rejects the request to prevent
+// direct Lambda invocations that bypass the authorizer.
+// Defense-in-depth: re-validates issuer, audience, and expiry even though
+// API Gateway checks these at authorizer time, guarding against misconfiguration
+// and clock skew between authorization and Lambda invocation.
+type APIGWExtractor struct {
+	expectedIssuer    string
+	expectedAudiences []string
+}
+
+// NewAPIGWExtractor creates an APIGWExtractor that re-validates issuer and audience
+// against the configured values as a defense-in-depth check.
+func NewAPIGWExtractor(issuer string, audiences []string) *APIGWExtractor {
+	return &APIGWExtractor{expectedIssuer: issuer, expectedAudiences: audiences}
+}
+
+// Extract maps the API Gateway authorizer claims to GithubClaims, re-validating
+// issuer, audience, and expiry for defense in depth.
+func (a *APIGWExtractor) Extract(_ context.Context, input ExtractionInput) (*types.GithubClaims, error) {
+	if len(input.AuthorizerClaims) == 0 {
+		return nil, fmt.Errorf("no authorizer claims present: request may have bypassed API Gateway JWT Authorizer")
+	}
+	return a.mapAPIGWClaims(input.AuthorizerClaims)
+}
+
+func (a *APIGWExtractor) mapAPIGWClaims(raw map[string]string) (*types.GithubClaims, error) {
+	repo := raw["repository"]
+	if repo == "" {
+		return nil, fmt.Errorf("missing required claim: repository")
+	}
+
+	// Re-validate issuer — guards against a reused or misconfigured JWT Authorizer.
+	iss := raw["iss"]
+	if iss != a.expectedIssuer {
+		return nil, fmt.Errorf("iss mismatch: got %q, want %q", iss, a.expectedIssuer)
+	}
+
+	// Re-validate audience — at least one must match the configured set.
+	aud := raw["aud"]
+	matched := false
+	for _, want := range a.expectedAudiences {
+		if aud == want {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil, fmt.Errorf("aud mismatch: token audience %q not in allowed set %v", aud, a.expectedAudiences)
+	}
+
+	// Re-validate expiry — API Gateway checks exp at auth time; Lambda cold starts
+	// can add enough delay that a short-lived token expires before processing.
+	expUnix, err := strconv.ParseInt(raw["exp"], 10, 64)
+	if err != nil || expUnix == 0 {
+		return nil, fmt.Errorf("missing or unparseable exp claim in authorizer context")
+	}
+	if time.Now().Unix() > expUnix {
+		return nil, fmt.Errorf("token has expired (exp=%d)", expUnix)
+	}
+
+	c := &types.GithubClaims{
+		Sub:                  raw["sub"],
+		Actor:                raw["actor"],
+		ActorID:              raw["actor_id"],
+		BaseRef:              raw["base_ref"],
+		EventName:            raw["event_name"],
+		HeadRef:              raw["head_ref"],
+		JobWorkflowRef:       raw["job_workflow_ref"],
+		JobWorkflowSha:       raw["job_workflow_sha"],
+		Ref:                  raw["ref"],
+		RefProtected:         raw["ref_protected"],
+		RefType:              raw["ref_type"],
+		Repository:           repo,
+		RepositoryID:         raw["repository_id"],
+		RepositoryOwner:      raw["repository_owner"],
+		RepositoryOwnerID:    raw["repository_owner_id"],
+		RepositoryVisibility: raw["repository_visibility"],
+		RunAttempt:           raw["run_attempt"],
+		RunID:                raw["run_id"],
+		RunNumber:            raw["run_number"],
+		RunnerEnvironment:    raw["runner_environment"],
+		Sha:                  raw["sha"],
+		Workflow:             raw["workflow"],
+		WorkflowRef:          raw["workflow_ref"],
+		WorkflowSha:          raw["workflow_sha"],
+	}
+
+	c.Issuer = iss
+	if aud != "" {
+		c.Audience = jwt.ClaimStrings{aud}
+	}
+	c.ExpiresAt = jwt.NewNumericDate(time.Unix(expUnix, 0))
+	if iat, err := strconv.ParseInt(raw["iat"], 10, 64); err == nil {
+		c.IssuedAt = jwt.NewNumericDate(time.Unix(iat, 0))
+	}
+
+	return c, nil
+}

--- a/internal/validator/apigw_extractor.go
+++ b/internal/validator/apigw_extractor.go
@@ -106,6 +106,10 @@ func (a *APIGWExtractor) mapAPIGWClaims(raw map[string]string) (*types.GithubCla
 	}
 	c.ExpiresAt = jwt.NewNumericDate(time.Unix(expUnix, 0))
 	if iat, err := strconv.ParseInt(raw["iat"], 10, 64); err == nil {
+		// Reject a future iat, matching self-mode's jwt.WithIssuedAt() check.
+		if time.Now().Unix() < iat {
+			return nil, fmt.Errorf("token iat is in the future (%d)", iat)
+		}
 		c.IssuedAt = jwt.NewNumericDate(time.Unix(iat, 0))
 	}
 

--- a/internal/validator/apigw_extractor_test.go
+++ b/internal/validator/apigw_extractor_test.go
@@ -1,0 +1,103 @@
+package validator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/boogy/aws-oidc-warden/internal/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIGWExtractor_Extract(t *testing.T) {
+	ex := validator.NewAPIGWExtractor("https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	claims, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		AuthorizerClaims: map[string]string{
+			"iss":        "https://token.actions.githubusercontent.com",
+			"sub":        "repo:org/repo:ref:refs/heads/main",
+			"aud":        "sts.amazonaws.com",
+			"exp":        "9999999999",
+			"iat":        "1000000000",
+			"repository": "org/repo",
+			"ref":        "refs/heads/main",
+			"ref_type":   "branch",
+			"actor":      "octocat",
+			"sha":        "abc123",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "org/repo", claims.Repository)
+	assert.Equal(t, "refs/heads/main", claims.Ref)
+	assert.Equal(t, "octocat", claims.Actor)
+	assert.Equal(t, "branch", claims.RefType)
+	assert.Equal(t, "https://token.actions.githubusercontent.com", claims.Issuer)
+}
+
+func TestAPIGWExtractor_MissingClaims(t *testing.T) {
+	ex := validator.NewAPIGWExtractor("https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		AuthorizerClaims: nil,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no authorizer claims")
+}
+
+func TestAPIGWExtractor_MissingRepository(t *testing.T) {
+	ex := validator.NewAPIGWExtractor("https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		AuthorizerClaims: map[string]string{"iss": "https://token.actions.githubusercontent.com"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repository")
+}
+
+func TestAPIGWExtractor_ExpiredToken(t *testing.T) {
+	ex := validator.NewAPIGWExtractor("https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		AuthorizerClaims: map[string]string{
+			"iss":        "https://token.actions.githubusercontent.com",
+			"aud":        "sts.amazonaws.com",
+			"repository": "org/repo",
+			"exp":        "1000000000", // far in the past
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestAPIGWExtractor_MissingExp(t *testing.T) {
+	ex := validator.NewAPIGWExtractor("https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		AuthorizerClaims: map[string]string{
+			"iss": "https://token.actions.githubusercontent.com", "aud": "sts.amazonaws.com",
+			"repository": "org/repo",
+			// no exp
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exp")
+}
+
+func TestAPIGWExtractor_IssuerMismatch(t *testing.T) {
+	ex := validator.NewAPIGWExtractor("https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		AuthorizerClaims: map[string]string{
+			"iss": "https://evil.example.com", "aud": "sts.amazonaws.com",
+			"repository": "org/repo", "exp": "9999999999",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "iss")
+}
+
+func TestAPIGWExtractor_AudienceMismatch(t *testing.T) {
+	ex := validator.NewAPIGWExtractor("https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		AuthorizerClaims: map[string]string{
+			"iss": "https://token.actions.githubusercontent.com", "aud": "wrong-audience",
+			"repository": "org/repo", "exp": "9999999999",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aud")
+}

--- a/internal/validator/apigw_extractor_test.go
+++ b/internal/validator/apigw_extractor_test.go
@@ -101,3 +101,21 @@ func TestAPIGWExtractor_AudienceMismatch(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "aud")
 }
+
+func TestAPIGWExtractor_MinimalClaims(t *testing.T) {
+	ex := validator.NewAPIGWExtractor("https://token.actions.githubusercontent.com", []string{"sts.amazonaws.com"})
+	claims, err := ex.Extract(context.Background(), validator.ExtractionInput{
+		AuthorizerClaims: map[string]string{
+			"iss":        "https://token.actions.githubusercontent.com",
+			"aud":        "sts.amazonaws.com",
+			"sub":        "repo:org/repo:ref:refs/heads/main",
+			"repository": "org/repo",
+			"exp":        "9999999999",
+			// no iat, actor, ref, ref_type, etc. — optional claims
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "org/repo", claims.Repository)
+	assert.Empty(t, claims.Actor, "absent optional claims must produce zero values")
+	assert.NotNil(t, claims.ExpiresAt)
+}

--- a/internal/validator/extractor.go
+++ b/internal/validator/extractor.go
@@ -1,0 +1,33 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/boogy/aws-oidc-warden/internal/types"
+)
+
+// ExtractionInput carries raw per-request data for claims extraction.
+// Only populate the fields relevant to the configured mode.
+type ExtractionInput struct {
+	// Token is the raw JWT string; used only in "self" mode.
+	Token string
+
+	// AuthorizerClaims contains pre-validated claims from API Gateway HTTP API
+	// v2 JWT Authorizer (event.requestContext.authorizer.jwt.claims).
+	AuthorizerClaims map[string]string
+
+	// ALBOIDCData is the value of the x-amzn-oidc-data header set by ALB OIDC.
+	// It is a JWT signed by ALB and must be verified before use.
+	ALBOIDCData string
+
+	// AWSRegion is required in "alb" mode to fetch the ALB signing public key
+	// from https://public-keys.auth.elb.{region}.amazonaws.com/{kid}.
+	AWSRegion string
+}
+
+// ClaimsExtractorInterface abstracts how GitHub OIDC claims are obtained.
+// Implementations either validate the JWT themselves ("self") or decode
+// pre-validated claims provided by a trusted upstream ("apigw", "alb").
+type ClaimsExtractorInterface interface {
+	Extract(ctx context.Context, input ExtractionInput) (*types.GithubClaims, error)
+}

--- a/internal/validator/extractor_test.go
+++ b/internal/validator/extractor_test.go
@@ -1,0 +1,21 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/boogy/aws-oidc-warden/internal/validator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractionInputFields(t *testing.T) {
+	input := validator.ExtractionInput{
+		Token:            "tok",
+		AuthorizerClaims: map[string]string{"repository": "org/repo"},
+		ALBOIDCData:      "alb-jwt",
+		AWSRegion:        "us-east-1",
+	}
+	assert.Equal(t, "tok", input.Token)
+	assert.Equal(t, "org/repo", input.AuthorizerClaims["repository"])
+	assert.Equal(t, "alb-jwt", input.ALBOIDCData)
+	assert.Equal(t, "us-east-1", input.AWSRegion)
+}

--- a/internal/validator/self_extractor.go
+++ b/internal/validator/self_extractor.go
@@ -1,0 +1,27 @@
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/boogy/aws-oidc-warden/internal/types"
+)
+
+// SelfExtractor validates the JWT signature and claims using the full
+// TokenValidatorInterface. This is the default mode.
+type SelfExtractor struct {
+	v TokenValidatorInterface
+}
+
+// NewSelfExtractor creates a SelfExtractor backed by the given validator.
+func NewSelfExtractor(v TokenValidatorInterface) *SelfExtractor {
+	return &SelfExtractor{v: v}
+}
+
+// Extract validates the JWT in input.Token and returns the verified claims.
+func (s *SelfExtractor) Extract(_ context.Context, input ExtractionInput) (*types.GithubClaims, error) {
+	if input.Token == "" {
+		return nil, fmt.Errorf("token is required in self-validation mode")
+	}
+	return s.v.Validate(input.Token)
+}

--- a/internal/validator/self_extractor_test.go
+++ b/internal/validator/self_extractor_test.go
@@ -1,0 +1,49 @@
+package validator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/boogy/aws-oidc-warden/internal/types"
+	"github.com/boogy/aws-oidc-warden/internal/validator"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockTokenValidator struct {
+	claims *types.GithubClaims
+	err    error
+}
+
+func (m *mockTokenValidator) Validate(token string) (*types.GithubClaims, error) {
+	return m.claims, m.err
+}
+func (m *mockTokenValidator) ParseToken(token string) (*types.GithubClaims, error) {
+	return m.claims, m.err
+}
+func (m *mockTokenValidator) FetchJWKS(issuer string) (*types.JWKS, error) { return nil, nil }
+func (m *mockTokenValidator) GenKeyFunc(jwks *types.JWKS) jwt.Keyfunc      { return nil }
+
+func TestSelfExtractor_Extract(t *testing.T) {
+	want := &types.GithubClaims{Repository: "org/repo"}
+	ex := validator.NewSelfExtractor(&mockTokenValidator{claims: want})
+
+	got, err := ex.Extract(context.Background(), validator.ExtractionInput{Token: "tok"})
+	require.NoError(t, err)
+	assert.Equal(t, want.Repository, got.Repository)
+}
+
+func TestSelfExtractor_Extract_ValidationError(t *testing.T) {
+	ex := validator.NewSelfExtractor(&mockTokenValidator{err: errors.New("bad sig")})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{Token: "tok"})
+	require.Error(t, err)
+}
+
+func TestSelfExtractor_Extract_EmptyToken(t *testing.T) {
+	ex := validator.NewSelfExtractor(&mockTokenValidator{})
+	_, err := ex.Extract(context.Background(), validator.ExtractionInput{Token: ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token is required")
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/big"
 	"net/http"
@@ -88,6 +89,9 @@ func (t *TokenValidator) Validate(token string) (*types.GithubClaims, error) {
 		return nil, err
 	}
 
+	// ParseToken already enforced the issuer via jwt.WithIssuer, but it reads a
+	// separate activeConfig() snapshot. Re-check against this call's snapshot so a
+	// hot-reloaded issuer change can't slip through the gap between the two reads.
 	if claims.Issuer != cfg.Issuer {
 		return nil, fmt.Errorf("issuer %s expected", cfg.Issuer)
 	}
@@ -135,6 +139,10 @@ func (t *TokenValidator) ParseToken(tokenString string) (*types.GithubClaims, er
 
 	if jwks == nil || len(jwks.Keys) == 0 {
 		return nil, errors.New("jwks is nil")
+	}
+	const maxJWKSKeys = 20
+	if len(jwks.Keys) > maxJWKSKeys {
+		return nil, fmt.Errorf("jwks contains too many keys (%d > %d)", len(jwks.Keys), maxJWKSKeys)
 	}
 
 	// Create token parser with strict validation.
@@ -231,7 +239,7 @@ func (t *TokenValidator) fetchJWKS(issuer string, force bool) (*types.JWKS, erro
 	var config struct {
 		JwksURI string `json:"jwks_uri"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&config); err != nil {
 		slog.Error("Failed to parse OIDC configuration", "error", err)
 		return nil, fmt.Errorf("failed to parse OIDC configuration: %w", err)
 	}
@@ -258,7 +266,7 @@ func (t *TokenValidator) fetchJWKS(issuer string, force bool) (*types.JWKS, erro
 	}
 
 	var jwks types.JWKS
-	if err := json.NewDecoder(jwksResp.Body).Decode(&jwks); err != nil {
+	if err := json.NewDecoder(io.LimitReader(jwksResp.Body, 1<<20)).Decode(&jwks); err != nil {
 		slog.Error("Failed to parse JWKS", "error", err)
 		return nil, fmt.Errorf("failed to parse JWKS: %w", err)
 	}
@@ -307,10 +315,16 @@ func parseRSAKey(key types.JSONWebKey) (*rsa.PublicKey, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode RSA exponent: %w", err)
 	}
-	return &rsa.PublicKey{
+	pub := &rsa.PublicKey{
 		N: new(big.Int).SetBytes(nBytes),
 		E: int(new(big.Int).SetBytes(eBytes).Int64()),
-	}, nil
+	}
+	// Defense-in-depth: reject undersized keys that could be served by a
+	// compromised JWKS source to enable offline signature forgery.
+	if pub.N.BitLen() < 2048 {
+		return nil, fmt.Errorf("RSA key too short: %d bits (minimum 2048)", pub.N.BitLen())
+	}
+	return pub, nil
 }
 
 func parseECKey(key types.JSONWebKey) (*ecdsa.PublicKey, error) {
@@ -329,11 +343,18 @@ func parseECKey(key types.JSONWebKey) (*ecdsa.PublicKey, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode EC y coordinate: %w", err)
 	}
-	return &ecdsa.PublicKey{
+	pub := &ecdsa.PublicKey{
 		Curve: curve,
 		X:     new(big.Int).SetBytes(xBytes),
 		Y:     new(big.Int).SetBytes(yBytes),
-	}, nil
+	}
+	// Validate the point lies on the declared curve (and is not the identity).
+	// ECDH() round-trips through crypto/ecdh, which rejects off-curve points —
+	// a non-deprecated alternative to elliptic.Curve.IsOnCurve.
+	if _, err := pub.ECDH(); err != nil {
+		return nil, fmt.Errorf("EC key point is not valid for curve %s: %w", key.Crv, err)
+	}
+	return pub, nil
 }
 
 func ecCurve(crv string) (elliptic.Curve, error) {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockCache is a mock implementation of the Cache interface
@@ -422,6 +423,23 @@ func TestGenKeyFunc(t *testing.T) {
 	assert.True(t, parsedToken.Valid)
 }
 
+func TestGenKeyFunc_RejectsShortRSAKey(t *testing.T) {
+	// A 1024-bit RSA key must be rejected by the minimum-key-size guard.
+	shortKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	assert.NoError(t, err)
+
+	keyID := "short-rsa-key"
+	jwks := createJWKS(keyID, &shortKey.PublicKey)
+
+	v := validator.NewTokenValidator(&config.Config{}, nil)
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Header["kid"] = keyID
+
+	_, err = v.GenKeyFunc(jwks)(token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RSA key too short")
+}
+
 func TestGenKeyFunc_MissingKID(t *testing.T) {
 	// Create a test JWKS
 	_, publicKey, err := generateRSAKey()
@@ -551,6 +569,98 @@ func TestParseToken_EmptyJWKS(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, claims)
 	assert.Contains(t, err.Error(), "jwks is nil")
+
+	mockCache.AssertExpectations(t)
+}
+
+func TestFetchJWKS_LargeOIDCDiscoveryRejected(t *testing.T) {
+	// A discovery document larger than 1 MB must be rejected cleanly (not OOM).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Write a syntactically valid JSON object padded well past 1 MB.
+		w.Write([]byte(`{"jwks_uri":"` + "https://example.com/jwks" + `","padding":"`)) //nolint:errcheck
+		padding := make([]byte, 2<<20)                                                  // 2 MB of zeros
+		for i := range padding {
+			padding[i] = 'x'
+		}
+		w.Write(padding)       //nolint:errcheck
+		w.Write([]byte(`"}}`)) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	mockCache := new(MockCache)
+	mockCache.On("Get", server.URL).Return(nil, false)
+
+	cfg := &config.Config{
+		Issuer: server.URL,
+		Cache:  &config.Cache{TTL: 10 * time.Minute},
+	}
+	v := validator.NewTokenValidator(cfg, mockCache)
+
+	_, err := v.FetchJWKS(server.URL)
+	assert.Error(t, err)
+}
+
+func TestFetchJWKS_LargeJWKSRejected(t *testing.T) {
+	// A JWKS payload larger than 1 MB must be rejected cleanly.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			cfg := struct {
+				JwksURI string `json:"jwks_uri"`
+			}{JwksURI: fmt.Sprintf("http://%s/jwks", r.Host)}
+			json.NewEncoder(w).Encode(cfg) //nolint:errcheck
+			return
+		}
+		// Return a JWKS body padded well past 1 MB.
+		w.Write([]byte(`{"keys":[{"kty":"RSA","padding":"`)) //nolint:errcheck
+		padding := make([]byte, 2<<20)
+		for i := range padding {
+			padding[i] = 'x'
+		}
+		w.Write(padding)        //nolint:errcheck
+		w.Write([]byte(`"}]}`)) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	mockCache := new(MockCache)
+	mockCache.On("Get", server.URL).Return(nil, false)
+
+	cfg := &config.Config{
+		Issuer: server.URL,
+		Cache:  &config.Cache{TTL: 10 * time.Minute},
+	}
+	v := validator.NewTokenValidator(cfg, mockCache)
+
+	_, err := v.FetchJWKS(server.URL)
+	assert.Error(t, err)
+}
+
+func TestParseToken_TooManyJWKSKeys(t *testing.T) {
+	// A JWKS with more than 20 keys must be rejected.
+	_, publicKey, err := generateRSAKey()
+	assert.NoError(t, err)
+	n := base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes())
+
+	keys := make([]types.JSONWebKey, 21)
+	for i := range keys {
+		keys[i] = types.JSONWebKey{KeyID: fmt.Sprintf("key-%d", i), KeyType: "RSA", Algorithm: "RS256", Use: "sig", N: n, E: e}
+	}
+	oversizedJWKS := &types.JWKS{Keys: keys}
+
+	mockCache := new(MockCache)
+	mockCache.On("Get", "https://example.com").Return(oversizedJWKS, true)
+
+	cfg := &config.Config{
+		Issuer: "https://example.com",
+		Cache:  &config.Cache{TTL: 10 * time.Minute},
+	}
+	v := validator.NewTokenValidator(cfg, mockCache)
+
+	_, err = v.ParseToken("invalid.token.string")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many keys")
 
 	mockCache.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

- Introduces `jwt_validation.mode` (`self` / `apigw` / `alb`) to offload JWT verification to API Gateway HTTP API v2 JWT Authorizer or ALB OIDC instead of doing it inline
- Adds `ClaimsExtractorInterface` with three implementations (`SelfExtractor`, `APIGWExtractor`, `ALBExtractor`) and a new `AwsApiGatewayV2` Lambda adapter + `cmd/apigatewayv2/` entry point
- Hardens validation across all modes: enforces `exp`/`iat`, rejects RSA keys < 2048 bits and EC points off their declared curve, fixes JWT failures returning HTTP 401 instead of 500

## Breaking Changes

- **S3/JSON config files must use `snake_case` keys** — `PascalCase` keys (`RepoRoleMappings`, `RoleSessionName`, etc.) are no longer accepted. Migrate any S3-hosted JSON configs before upgrading.
- **`workflow_ref` constraint regex is now auto-anchored** — previously matched as a substring; now compiled as `^(?:...)$` like all other constraints. Update patterns relying on partial matching.

## Added

- `jwt_validation.mode` config option + `AOW_JWT_VALIDATION_MODE` / `AOW_JWT_VALIDATION_ALB_EXPECTED_SIGNER` env vars
- `ClaimsExtractorInterface` in `internal/validator/` with `SelfExtractor`, `APIGWExtractor`, `ALBExtractor`
- `AwsApiGatewayV2` adapter (`internal/handler/apigatewayv2.go`) and `cmd/apigatewayv2/` entry point
- In-memory ALB public key cache (5-minute TTL) in `ALBExtractor`
- `ParseRoleOnlyRequestBody` for delegated-mode requests (only `role` ARN required in body)

## Fixed

- `exp` required and future-`iat` tokens rejected in ALB and APIGW delegated modes (matches self-mode)
- RSA JWKS keys < 2048 bits rejected; EC JWKS keys validated to lie on declared curve
- JWT validation failures now return HTTP 401 (was HTTP 500)
- Frontend adapters share `classifyError` helper — removed duplicated error-classification switches
- Malformed role ARNs return `ErrInvalidRoleFormat` (HTTP 400) instead of empty-role misreport

## Test Plan

- [x] CI passes: `go test ./...`, `golangci-lint`, `gosec`, Trivy scan
- [x] `jwt_validation.mode: self` — existing behaviour unchanged
- [ ] `jwt_validation.mode: apigw` — claims extracted from `x-amzn-oidc-data` context
- [ ] `jwt_validation.mode: alb` — ES256 signature verified against ALB public key endpoint