### PR TITLE
fix(ci): prerelease tags never move *-latest/latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,20 +95,32 @@ jobs:
       # CLI (a `tags:` key under .ko.yaml `builds[]` is not a real ko option
       # and is silently ignored, which is why this used explicit --tags before
       # #244's refactor). apigateway is the default module and also carries
-      # the bare <tag>/latest.
+      # the bare <tag>/latest. A prerelease tag (v*-rc.N, v*-beta, ...) never
+      # touches *-latest/latest — only a final vX.Y.Z tag moves those.
+      - name: Determine image tags
+        id: tags
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          TAGS="${{ matrix.module }}-$VERSION"
+          if [[ "$VERSION" != *-* ]]; then
+            TAGS="$TAGS,${{ matrix.module }}-latest"
+            if [ "${{ matrix.module }}" = "apigateway" ]; then
+              TAGS="$TAGS,$VERSION,latest"
+            fi
+          elif [ "${{ matrix.module }}" = "apigateway" ]; then
+            TAGS="$TAGS,$VERSION"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
       - name: Build and push ${{ matrix.module }} to GHCR
         id: ghcr
         env:
           KO_DOCKER_REPO: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.REPO_NAME }}
-          VERSION: ${{ github.ref_name }}
         run: |
           echo "Building and pushing ${{ matrix.module }} to GHCR..."
           echo "KO_DOCKER_REPO: $KO_DOCKER_REPO"
-          TAGS="${{ matrix.module }}-$VERSION,${{ matrix.module }}-latest"
-          if [ "${{ matrix.module }}" = "apigateway" ]; then
-            TAGS="$TAGS,$VERSION,latest"
-          fi
-          IMAGE=$(ko publish ./cmd/${{ matrix.module }}/ --bare --tags="$TAGS")
+          IMAGE=$(ko publish ./cmd/${{ matrix.module }}/ --bare --tags="${{ steps.tags.outputs.tags }}")
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           echo "digest=${IMAGE##*@}" >> "$GITHUB_OUTPUT"
         timeout-minutes: 15
@@ -117,15 +129,10 @@ jobs:
         id: dockerhub
         env:
           KO_DOCKER_REPO: ${{ env.DOCKERHUB_REGISTRY }}/${{ github.repository_owner }}/${{ env.REPO_NAME }}
-          VERSION: ${{ github.ref_name }}
         run: |
           echo "Building and pushing ${{ matrix.module }} to Docker Hub..."
           echo "KO_DOCKER_REPO: $KO_DOCKER_REPO"
-          TAGS="${{ matrix.module }}-$VERSION,${{ matrix.module }}-latest"
-          if [ "${{ matrix.module }}" = "apigateway" ]; then
-            TAGS="$TAGS,$VERSION,latest"
-          fi
-          IMAGE=$(ko publish ./cmd/${{ matrix.module }}/ --bare --tags="$TAGS")
+          IMAGE=$(ko publish ./cmd/${{ matrix.module }}/ --bare --tags="${{ steps.tags.outputs.tags }}")
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           echo "digest=${IMAGE##*@}" >> "$GITHUB_OUTPUT"
         timeout-minutes: 15

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -140,6 +140,7 @@ checksum:
 
 release:
   draft: false
+  prerelease: auto
 
 changelog:
   sort: asc

--- a/Makefile
+++ b/Makefile
@@ -164,10 +164,18 @@ ko-publish: verify-ko
 	@echo "Publishing container images to $(KO_DOCKER_REPO)..."
 	@# ko has no config-file tag scheme; --tags must be passed per module (a
 	@# bare multi-importpath publish would collide all modules onto one image).
-	@KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/apigateway --bare --tags=apigateway-$(VERSION),apigateway-latest,$(VERSION),latest
-	@KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/apigatewayv2 --bare --tags=apigatewayv2-$(VERSION),apigatewayv2-latest
-	@KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/alb --bare --tags=alb-$(VERSION),alb-latest
-	@KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/lambdaurl --bare --tags=lambdaurl-$(VERSION),lambdaurl-latest
+	@# A prerelease VERSION (vX.Y.Z-rc.N) never moves *-latest/latest.
+	@if echo "$(VERSION)" | grep -q -- '-'; then \
+		KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/apigateway --bare --tags=apigateway-$(VERSION),$(VERSION); \
+		KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/apigatewayv2 --bare --tags=apigatewayv2-$(VERSION); \
+		KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/alb --bare --tags=alb-$(VERSION); \
+		KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/lambdaurl --bare --tags=lambdaurl-$(VERSION); \
+	else \
+		KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/apigateway --bare --tags=apigateway-$(VERSION),apigateway-latest,$(VERSION),latest; \
+		KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/apigatewayv2 --bare --tags=apigatewayv2-$(VERSION),apigatewayv2-latest; \
+		KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/alb --bare --tags=alb-$(VERSION),alb-latest; \
+		KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko publish ./cmd/lambdaurl --bare --tags=lambdaurl-$(VERSION),lambdaurl-latest; \
+	fi
 
 .PHONY: ko-publish-all
 ko-publish-all: ko-publish


### PR DESCRIPTION
## Summary
- Pushing `v2.0.0-rc.1`/`v2.0.0-rc.2` as dry runs (see #255) exposed a second issue: **any** pushed tag — including RCs — updates `apigateway-latest`, `alb-latest`, `lambdaurl-latest`, `apigatewayv2-latest`, and the bare `latest`/`<tag>` tags. Anyone pulling `:latest` right now gets the `v2.0.0-rc.2` build, not the last stable release.
- `release.yml`'s `images` job and `make ko-publish` now only include `*-latest`/`latest` in the ko `--tags` list when the ref has no semver prerelease suffix (no `-` in the tag). A final `vX.Y.Z` tag still updates `latest` as before; a `-rc.N`/`-beta`/`-alpha` tag only publishes its own versioned tag.
- Added `release.prerelease: auto` to `.goreleaser.yaml` so a prerelease tag is flagged as a GitHub prerelease instead of showing as the repo's "Latest release".

## Note
`latest` currently points at `v2.0.0-rc.2`'s build from the earlier dry run. That's a wash once the real `v2.0.0` tag ships (same app code), but flagging in case anyone pulled `:latest` in the interim.

## Test plan
- [ ] CI passes
- [ ] Push another RC tag (e.g. `v2.0.0-rc.3`) and confirm `*-latest`/`latest` do NOT change on GHCR/Docker Hub, and the GitHub release is marked prerelease
- [ ] Cut real `v2.0.0` tag and confirm `latest` updates normally