### PR TITLE
fix(deploy): correct api_endpoint URL and harden OpenTofu quick setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **OpenTofu `api_endpoint` output** — the `$default` stage `invoke_url` ends
+  with a trailing slash, so the output rendered `…amazonaws.com//verify`;
+  HTTP APIs do not normalize double slashes, making the documented smoke-test
+  URL a 404. The slash is now trimmed before appending `/verify`.
+
+### Changed
+
+- **OpenTofu quick-setup guardrails** — a missing `dist/function.zip` now
+  fails `plan` with a clear "run deploy/opentofu/build.sh first" precondition
+  instead of a raw `filebase64sha256` error, and the API Gateway JWT
+  Authorizer (`apigw` mode) now defaults to `var.issuer` / `var.audiences`
+  so the authorizer and the rendered `config.yaml` cannot drift apart
+  (`jwt_authorizer_issuer` / `jwt_authorizer_audiences` remain as explicit
+  overrides).
+
 ## [2.0.0] - 2026-07-02
 
 Multi-issuer, any-provider release. v2 validates OIDC tokens from any number of

--- a/deploy/opentofu/main.tf
+++ b/deploy/opentofu/main.tf
@@ -149,8 +149,10 @@ module "apigateway" {
   lambda_function_name = module.lambda.function_name
   # "apigw" mode: use v2 payload format + provision a JWT Authorizer so API GW
   # validates the token before invoking Lambda (Lambda reads pre-validated claims).
-  payload_format_version   = var.jwt_validation_mode == "apigw" ? "2.0" : "1.0"
-  enable_jwt_authorizer    = var.jwt_validation_mode == "apigw"
-  jwt_authorizer_issuer    = var.jwt_authorizer_issuer
-  jwt_authorizer_audiences = var.jwt_authorizer_audiences
+  payload_format_version = var.jwt_validation_mode == "apigw" ? "2.0" : "1.0"
+  enable_jwt_authorizer  = var.jwt_validation_mode == "apigw"
+  # Authorizer follows the config issuer/audiences unless explicitly overridden,
+  # so the two validation layers cannot drift apart in apigw mode.
+  jwt_authorizer_issuer    = coalesce(var.jwt_authorizer_issuer, var.issuer)
+  jwt_authorizer_audiences = var.jwt_authorizer_audiences != null ? var.jwt_authorizer_audiences : var.audiences
 }

--- a/deploy/opentofu/modules/apigateway/outputs.tf
+++ b/deploy/opentofu/modules/apigateway/outputs.tf
@@ -5,7 +5,9 @@ output "api_id" {
 
 output "api_endpoint" {
   description = "Invoke URL for the verify route."
-  value       = "${aws_apigatewayv2_stage.this.invoke_url}/verify"
+  # invoke_url ends with "/" for the $default stage; trim it so the path is
+  # "/verify", not "//verify" (HTTP APIs do not normalize double slashes).
+  value = "${trimsuffix(aws_apigatewayv2_stage.this.invoke_url, "/")}/verify"
 }
 
 output "jwt_authorizer_id" {

--- a/deploy/opentofu/modules/lambda/main.tf
+++ b/deploy/opentofu/modules/lambda/main.tf
@@ -14,7 +14,14 @@ resource "aws_lambda_function" "this" {
   timeout       = var.timeout
 
   filename         = var.zip_path
-  source_code_hash = filebase64sha256(var.zip_path)
+  source_code_hash = fileexists(var.zip_path) ? filebase64sha256(var.zip_path) : null
+
+  lifecycle {
+    precondition {
+      condition     = fileexists(var.zip_path)
+      error_message = "Deployment zip not found (modules/lambda var.zip_path). Run deploy/opentofu/build.sh first — 'build.sh' for self mode, 'build.sh apigatewayv2' for apigw mode."
+    }
+  }
 
   reserved_concurrent_executions = var.reserved_concurrency
 

--- a/deploy/opentofu/terraform.tfvars.example
+++ b/deploy/opentofu/terraform.tfvars.example
@@ -73,5 +73,7 @@ role_mappings = [
 # "alb" mode is NOT supported by this stack — it needs the `alb` Lambda binary
 # behind an Application Load Balancer, which this module does not provision.
 jwt_validation_mode = "self"
+# The JWT Authorizer follows `issuer`/`audiences` above by default; override
+# only if the authorizer must validate against a different issuer/audiences.
 # jwt_authorizer_issuer    = "https://token.actions.githubusercontent.com"
 # jwt_authorizer_audiences = ["sts.amazonaws.com"]

--- a/deploy/opentofu/variables.tf
+++ b/deploy/opentofu/variables.tf
@@ -193,12 +193,12 @@ variable "jwt_validation_mode" {
 
 variable "jwt_authorizer_issuer" {
   type        = string
-  description = "OIDC issuer URL for the API Gateway JWT Authorizer. Only used when jwt_validation_mode = 'apigw'."
-  default     = "https://token.actions.githubusercontent.com"
+  description = "OIDC issuer URL for the API Gateway JWT Authorizer. Only used when jwt_validation_mode = 'apigw'. Defaults to var.issuer — set only to diverge from it."
+  default     = null
 }
 
 variable "jwt_authorizer_audiences" {
   type        = list(string)
-  description = "Accepted audiences for the API Gateway JWT Authorizer. Only used when jwt_validation_mode = 'apigw'."
-  default     = ["sts.amazonaws.com"]
+  description = "Accepted audiences for the API Gateway JWT Authorizer. Only used when jwt_validation_mode = 'apigw'. Defaults to var.audiences — set only to diverge from them."
+  default     = null
 }


### PR DESCRIPTION
## Summary

Review of the `deploy/opentofu` stack found one real bug and two quick-setup frictions; all fixed here. `tofu fmt` and `tofu validate` pass.

### Fixed
- **`api_endpoint` output rendered `https://…amazonaws.com//verify`.** The AWS provider returns the `$default` stage `invoke_url` with a trailing slash (confirmed in provider source, `APIGatewayV2InvokeURL`), and HTTP APIs do not normalize double slashes — the documented smoke-test URL 404'd. Now trimmed before appending `/verify`; named stages are unaffected (`trimsuffix` is a no-op there).

### Changed
- **Missing `dist/function.zip` now fails `plan` with a clear precondition** ("run deploy/opentofu/build.sh first") instead of a raw `filebase64sha256` error — the most likely first-run mistake.
- **`jwt_authorizer_issuer`/`jwt_authorizer_audiences` now default to `var.issuer`/`var.audiences`** so the API GW JWT Authorizer and the rendered `config.yaml` cannot silently drift apart in `apigw` mode. Both remain available as explicit overrides. No behavior change for anyone using the previous defaults, which matched `issuer`/`audiences` defaults.

## Verification
- Rendered the exact `yamlencode` output for `terraform.tfvars.example` (including the `null`s that unset `optional()` attributes produce) and ran it through the service's real load path (`MergeBytes` + `Validate` + `AuthorizeRoles`) in a temporary Go test — parses, validates, and authorizes the example mapping; nulls decode to zero values without leaking into `Extra` conditions.
- Confirmed env-var seams (`AOW_S3_CONFIG_BUCKET`/`AOW_S3_CONFIG_PATH`, and the CloudFormation template's `AOW_CACHE_*`/`AOW_JWT_VALIDATION_MODE`) exist in `envBindings`.
- Confirmed the DynamoDB table schema (`Key`/`TTL`) matches `internal/cache/dynamodb.go` in both the module and the CloudFormation template.
- `tofu validate` + `tofu fmt -check -recursive` pass; a full `plan` needs AWS credentials.