### PR TITLE
feat(deploy): REST API + WAF option to harden the public endpoint

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -91,12 +91,12 @@ Build the correct binary before running `tofu apply`:
 
 The endpoint is public. The application already denies tokens from unconfigured issuers with 401 **before any JWKS fetch** (no SSRF surface, minimal CPU), but in `self` mode every request — valid or junk — still invokes the Lambda. Defense is layered; each layer stops traffic the previous one lets through:
 
-| Layer | Stops junk traffic… | Knob |
-| --- | --- | --- |
-| WAF (REST API only) or JWT Authorizer (`apigw` mode) | **before Lambda invocation** | `enable_waf` / `jwt_validation_mode` |
-| API Gateway stage throttling | before invocation, above rate cap | `throttling_burst_limit`, `throttling_rate_limit` |
-| In-app validation (unknown issuer → 401 pre-JWKS) | inside the Lambda, cheaply | always on |
-| Lambda reserved concurrency | caps total concurrent invocations (cost/blast radius) | `lambda_reserved_concurrency` |
+| Layer                                                | Stops junk traffic…                                   | Knob                                              |
+| ---------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------- |
+| WAF (REST API only) or JWT Authorizer (`apigw` mode) | **before Lambda invocation**                          | `enable_waf` / `jwt_validation_mode`              |
+| API Gateway stage throttling                         | before invocation, above rate cap                     | `throttling_burst_limit`, `throttling_rate_limit` |
+| In-app validation (unknown issuer → 401 pre-JWKS)    | inside the Lambda, cheaply                            | always on                                         |
+| Lambda reserved concurrency                          | caps total concurrent invocations (cost/blast radius) | `lambda_reserved_concurrency`                     |
 
 The pre-invocation layer depends on the API Gateway flavor (`api_gateway_type`), because AWS ties each protection to one flavor:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -87,6 +87,30 @@ Build the correct binary before running `tofu apply`:
 
 ---
 
+## Hardening the Public Endpoint
+
+The endpoint is public. The application already denies tokens from unconfigured issuers with 401 **before any JWKS fetch** (no SSRF surface, minimal CPU), but in `self` mode every request — valid or junk — still invokes the Lambda. Defense is layered; each layer stops traffic the previous one lets through:
+
+| Layer | Stops junk traffic… | Knob |
+| --- | --- | --- |
+| WAF (REST API only) or JWT Authorizer (`apigw` mode) | **before Lambda invocation** | `enable_waf` / `jwt_validation_mode` |
+| API Gateway stage throttling | before invocation, above rate cap | `throttling_burst_limit`, `throttling_rate_limit` |
+| In-app validation (unknown issuer → 401 pre-JWKS) | inside the Lambda, cheaply | always on |
+| Lambda reserved concurrency | caps total concurrent invocations (cost/blast radius) | `lambda_reserved_concurrency` |
+
+The pre-invocation layer depends on the API Gateway flavor (`api_gateway_type`), because AWS ties each protection to one flavor:
+
+- **HTTP API (v2, `"http"`, default)** — supports the **JWT Authorizer**: with `jwt_validation_mode = "apigw"`, API Gateway validates the token's signature/issuer/audience against JWKS and rejects invalid tokens at the gateway — zero Lambda invocations for junk. Limitation: one issuer per authorizer (delegated mode enforces a single configured issuer). **WAF cannot attach to HTTP APIs.**
+- **REST API (v1, `"rest"`)** — supports **AWS WAF** (`enable_waf = true`): a per-source-IP rate-based rule (`waf_rate_limit`, default 300 req/5 min), `AWSManagedRulesCommonRuleSet`, and a request-shape rule that blocks anything other than `POST /verify`. This is the hardened posture for **multi-issuer `self` mode**, where the JWT Authorizer doesn't fit. Uses the same `apigateway` binary and self-mode request format — no rebuild needed when switching from `"http"` + self.
+
+**Pick per issuer count:** single issuer → `"http"` + `jwt_validation_mode = "apigw"`; multiple issuers → `"rest"` + `enable_waf = true`. Preconditions enforce the valid combinations at plan time.
+
+**No IP allowlisting:** GitHub-hosted runners use vast, constantly-changing Azure IP ranges and self-hosted runners can be anywhere — WAF IP sets or resource policies would break legitimate callers, so neither posture uses them.
+
+The CloudFormation quickstart provisions an HTTP API only; use the OpenTofu stack for the REST + WAF posture.
+
+---
+
 ## Smoke Tests
 
 **Self mode:**

--- a/deploy/opentofu/hardening.tftest.hcl
+++ b/deploy/opentofu/hardening.tftest.hcl
@@ -1,0 +1,101 @@
+# Plan-time wiring tests for the endpoint-hardening variables. Runs with a
+# mock AWS provider — no credentials needed: `tofu test`.
+
+mock_provider "aws" {
+  # The auto-generated mock value is a random string, which fails
+  # aws_iam_role's JSON validation — return a minimal valid policy instead.
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::111122223333:role/mock-role"
+    }
+  }
+
+  mock_resource "aws_apigatewayv2_api" {
+    defaults = {
+      execution_arn = "arn:aws:execute-api:eu-west-1:111122223333:mockapiv2"
+    }
+  }
+
+  mock_resource "aws_api_gateway_rest_api" {
+    defaults = {
+      execution_arn = "arn:aws:execute-api:eu-west-1:111122223333:mockapiv1"
+    }
+  }
+
+  mock_resource "aws_api_gateway_stage" {
+    defaults = {
+      arn = "arn:aws:apigateway:eu-west-1::/restapis/mockapiv1/stages/v1"
+    }
+  }
+
+  mock_resource "aws_wafv2_web_acl" {
+    defaults = {
+      arn = "arn:aws:wafv2:eu-west-1:111122223333:regional/webacl/mock/00000000-0000-0000-0000-000000000000"
+    }
+  }
+}
+
+variables {
+  region = "eu-west-1"
+}
+
+# (a) Defaults: HTTP API only, no REST/WAF resources.
+run "defaults_http_api" {
+  command = plan
+
+  assert {
+    condition     = length(module.apigateway) == 1 && length(module.apigateway_rest) == 0
+    error_message = "Defaults must provision the HTTP API module only."
+  }
+}
+
+# (b) REST + WAF: REST API module only; WAF web ACL provisioned.
+run "rest_with_waf" {
+  command = plan
+
+  variables {
+    api_gateway_type = "rest"
+    enable_waf       = true
+  }
+
+  assert {
+    condition     = length(module.apigateway) == 0 && length(module.apigateway_rest) == 1
+    error_message = "api_gateway_type = 'rest' must provision the REST API module only."
+  }
+
+  assert {
+    condition     = length(module.apigateway_rest[0].web_acl_arn) > 0
+    error_message = "enable_waf must provision a WAF web ACL."
+  }
+}
+
+# (c) Invalid combination: apigw JWT-authorizer mode on a REST API must fail
+# the plan-time precondition.
+run "apigw_mode_requires_http_api" {
+  command = plan
+
+  variables {
+    api_gateway_type    = "rest"
+    jwt_validation_mode = "apigw"
+  }
+
+  expect_failures = [aws_s3_object.config]
+}
+
+# (d) Invalid combination: WAF on an HTTP API must fail the precondition.
+run "waf_requires_rest_api" {
+  command = plan
+
+  variables {
+    api_gateway_type = "http"
+    enable_waf       = true
+  }
+
+  expect_failures = [aws_s3_object.config]
+}

--- a/deploy/opentofu/main.tf
+++ b/deploy/opentofu/main.tf
@@ -104,6 +104,14 @@ resource "aws_s3_object" "config" {
       condition     = !(var.enable_dynamodb_cache && var.enable_s3_cache)
       error_message = "enable_dynamodb_cache and enable_s3_cache are mutually exclusive."
     }
+    precondition {
+      condition     = !(var.jwt_validation_mode == "apigw" && var.api_gateway_type != "http")
+      error_message = "jwt_validation_mode = 'apigw' requires api_gateway_type = 'http' — JWT Authorizers exist only on HTTP APIs (v2)."
+    }
+    precondition {
+      condition     = !(var.enable_waf && var.api_gateway_type != "rest")
+      error_message = "enable_waf requires api_gateway_type = 'rest' — AWS WAF cannot attach to HTTP APIs (v2)."
+    }
   }
 }
 
@@ -124,14 +132,15 @@ module "iam" {
 
 # ---- Lambda ----
 module "lambda" {
-  source             = "./modules/lambda"
-  function_name      = var.name_prefix
-  role_arn           = module.iam.role_arn
-  zip_path           = "${path.module}/dist/function.zip"
-  architecture       = var.lambda_architecture
-  memory_size        = var.lambda_memory_size
-  timeout            = var.lambda_timeout
-  log_retention_days = var.log_retention_days
+  source               = "./modules/lambda"
+  function_name        = var.name_prefix
+  role_arn             = module.iam.role_arn
+  zip_path             = "${path.module}/dist/function.zip"
+  architecture         = var.lambda_architecture
+  memory_size          = var.lambda_memory_size
+  timeout              = var.lambda_timeout
+  log_retention_days   = var.log_retention_days
+  reserved_concurrency = var.lambda_reserved_concurrency
   environment_variables = {
     AOW_S3_CONFIG_BUCKET = module.config_bucket.bucket_id
     AOW_S3_CONFIG_PATH   = local.config_key
@@ -142,7 +151,10 @@ module "lambda" {
 }
 
 # ---- API Gateway ----
+# Exactly one front-end is provisioned, selected by var.api_gateway_type:
+# "http" (v2) supports the JWT Authorizer; "rest" (v1) supports WAF attachment.
 module "apigateway" {
+  count                = var.api_gateway_type == "http" ? 1 : 0
   source               = "./modules/apigateway"
   name                 = var.name_prefix
   lambda_invoke_arn    = module.lambda.invoke_arn
@@ -155,4 +167,20 @@ module "apigateway" {
   # so the two validation layers cannot drift apart in apigw mode.
   jwt_authorizer_issuer    = coalesce(var.jwt_authorizer_issuer, var.issuer)
   jwt_authorizer_audiences = var.jwt_authorizer_audiences != null ? var.jwt_authorizer_audiences : var.audiences
+  throttling_burst_limit   = var.throttling_burst_limit
+  throttling_rate_limit    = var.throttling_rate_limit
+}
+
+module "apigateway_rest" {
+  count                  = var.api_gateway_type == "rest" ? 1 : 0
+  source                 = "./modules/apigateway-rest"
+  name                   = var.name_prefix
+  lambda_invoke_arn      = module.lambda.invoke_arn
+  lambda_function_name   = module.lambda.function_name
+  throttling_burst_limit = var.throttling_burst_limit
+  throttling_rate_limit  = var.throttling_rate_limit
+  enable_waf             = var.enable_waf
+  waf_rate_limit         = var.waf_rate_limit
+  waf_common_rule_set    = var.waf_common_rule_set
+  tags                   = var.tags
 }

--- a/deploy/opentofu/modules/apigateway-rest/main.tf
+++ b/deploy/opentofu/modules/apigateway-rest/main.tf
@@ -1,0 +1,209 @@
+# REST API (v1) front-end for the `apigateway` binary (self mode). Unlike the
+# HTTP API (v2) module, a REST API accepts an AWS WAFv2 web ACL, giving
+# multi-issuer self-mode deployments pre-invocation protection (rate limiting,
+# managed rules, request-shape filtering) that HTTP APIs cannot attach.
+
+resource "aws_api_gateway_rest_api" "this" {
+  name = var.name
+  tags = var.tags
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+resource "aws_api_gateway_resource" "verify" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  parent_id   = aws_api_gateway_rest_api.this.root_resource_id
+  path_part   = "verify"
+}
+
+resource "aws_api_gateway_method" "post_verify" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.verify.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "lambda" {
+  rest_api_id             = aws_api_gateway_rest_api.this.id
+  resource_id             = aws_api_gateway_resource.verify.id
+  http_method             = aws_api_gateway_method.post_verify.http_method
+  type                    = "AWS_PROXY"
+  integration_http_method = "POST"
+  uri                     = var.lambda_invoke_arn
+}
+
+resource "aws_api_gateway_deployment" "this" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+
+  # Redeploy whenever the API surface changes.
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_resource.verify.id,
+      aws_api_gateway_method.post_verify.id,
+      aws_api_gateway_integration.lambda.id,
+    ]))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "this" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  deployment_id = aws_api_gateway_deployment.this.id
+  stage_name    = var.stage_name
+  tags          = var.tags
+}
+
+resource "aws_api_gateway_method_settings" "throttling" {
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  stage_name  = aws_api_gateway_stage.this.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_burst_limit = var.throttling_burst_limit
+    throttling_rate_limit  = var.throttling_rate_limit
+  }
+}
+
+resource "aws_lambda_permission" "apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.this.execution_arn}/*/*"
+}
+
+# ---- WAF ----
+# No IP sets or geo rules: legitimate callers are GitHub Actions runners, whose
+# IP ranges are vast and constantly changing (GitHub-hosted) or arbitrary
+# (self-hosted). Protection comes from per-source rate limiting, managed rules,
+# and dropping anything that is not a POST to /verify.
+resource "aws_wafv2_web_acl" "this" {
+  count = var.enable_waf ? 1 : 0
+
+  name  = "${var.name}-waf"
+  scope = "REGIONAL"
+  tags  = var.tags
+
+  default_action {
+    allow {}
+  }
+
+  # Drop requests that are not POST /verify — scanners and probes never reach
+  # the Lambda.
+  rule {
+    name     = "request-shape"
+    priority = 0
+
+    action {
+      block {}
+    }
+
+    statement {
+      not_statement {
+        statement {
+          and_statement {
+            statement {
+              byte_match_statement {
+                search_string         = "POST"
+                positional_constraint = "EXACTLY"
+                field_to_match {
+                  method {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                search_string         = "/verify"
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.name}-request-shape"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Per-source-IP rate cap. Bounds abuse from any single source without
+  # restricting who may call.
+  rule {
+    name     = "rate-limit"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.waf_rate_limit
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.name}-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.waf_common_rule_set ? [1] : []
+    content {
+      name     = "aws-common-rules"
+      priority = 2
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          name        = "AWSManagedRulesCommonRuleSet"
+          vendor_name = "AWS"
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${var.name}-common-rules"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.name}-waf"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "this" {
+  count = var.enable_waf ? 1 : 0
+
+  resource_arn = aws_api_gateway_stage.this.arn
+  web_acl_arn  = aws_wafv2_web_acl.this[0].arn
+}

--- a/deploy/opentofu/modules/apigateway-rest/outputs.tf
+++ b/deploy/opentofu/modules/apigateway-rest/outputs.tf
@@ -1,0 +1,14 @@
+output "api_id" {
+  description = "REST API ID."
+  value       = aws_api_gateway_rest_api.this.id
+}
+
+output "api_endpoint" {
+  description = "Invoke URL for the verify route."
+  value       = "${aws_api_gateway_stage.this.invoke_url}/verify"
+}
+
+output "web_acl_arn" {
+  description = "WAF web ACL ARN, or empty string when not provisioned."
+  value       = var.enable_waf ? aws_wafv2_web_acl.this[0].arn : ""
+}

--- a/deploy/opentofu/modules/apigateway-rest/variables.tf
+++ b/deploy/opentofu/modules/apigateway-rest/variables.tf
@@ -1,0 +1,56 @@
+variable "name" {
+  type        = string
+  description = "API name."
+}
+
+variable "lambda_invoke_arn" {
+  type        = string
+  description = "Lambda invoke ARN."
+}
+
+variable "lambda_function_name" {
+  type        = string
+  description = "Lambda function name (for the invoke permission)."
+}
+
+variable "stage_name" {
+  type        = string
+  description = "Stage name (part of the invoke URL path)."
+  default     = "v1"
+}
+
+variable "throttling_burst_limit" {
+  type        = number
+  description = "Stage-wide burst limit."
+  default     = 50
+}
+
+variable "throttling_rate_limit" {
+  type        = number
+  description = "Stage-wide steady-state rate limit."
+  default     = 100
+}
+
+variable "enable_waf" {
+  type        = bool
+  description = "Attach an AWS WAFv2 web ACL (rate limiting + managed rules + request-shape filtering) to the stage."
+  default     = false
+}
+
+variable "waf_rate_limit" {
+  type        = number
+  description = "WAF rate-based rule: max requests per source IP per 5-minute window. AWS minimum is 10."
+  default     = 300
+}
+
+variable "waf_common_rule_set" {
+  type        = bool
+  description = "Include AWSManagedRulesCommonRuleSet in the web ACL. Disable if it false-positives on JWT request bodies."
+  default     = true
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to API Gateway and WAF resources."
+  default     = {}
+}

--- a/deploy/opentofu/outputs.tf
+++ b/deploy/opentofu/outputs.tf
@@ -1,6 +1,11 @@
 output "api_endpoint" {
   description = "POST this URL with {\"token\":\"...\",\"role\":\"...\"}."
-  value       = module.apigateway.api_endpoint
+  value       = coalesce(one(module.apigateway[*].api_endpoint), one(module.apigateway_rest[*].api_endpoint))
+}
+
+output "waf_web_acl_arn" {
+  description = "WAF web ACL ARN (rest + enable_waf only), or null."
+  value       = var.enable_waf ? one(module.apigateway_rest[*].web_acl_arn) : null
 }
 
 output "lambda_function_name" {

--- a/deploy/opentofu/terraform.tfvars.example
+++ b/deploy/opentofu/terraform.tfvars.example
@@ -62,12 +62,32 @@ role_mappings = [
 #   allowed_accounts = ["111122223333", "444455556666"]
 # }
 
+# --- Public endpoint hardening ---
+# The endpoint is public; unknown-issuer tokens are denied in-app (401, before
+# any JWKS fetch), but in self mode the Lambda is still INVOKED per request.
+# To reject junk traffic before invocation, pick per issuer count:
+#   single issuer  -> jwt_validation_mode = "apigw" (JWT Authorizer on the HTTP
+#                     API rejects invalid tokens at the gateway; RECOMMENDED)
+#   multi-issuer   -> api_gateway_type = "rest" + enable_waf = true (WAF rate
+#     (self mode)     limiting + managed rules + POST-/verify-only filtering;
+#                     WAF cannot attach to HTTP APIs)
+# No IP allowlisting in either posture: GitHub-hosted runner IP ranges are vast
+# and dynamic, and self-hosted runners can be anywhere.
+# api_gateway_type = "rest"
+# enable_waf       = true
+# waf_rate_limit   = 300 # requests per source IP per 5 min
+# Always-on knobs (both API types):
+# throttling_burst_limit      = 50
+# throttling_rate_limit       = 100
+# lambda_reserved_concurrency = 50 # cap invocation blast radius; -1 = unreserved
+
 # --- JWT Validation Mode ---
 # "self"  (default) — Lambda validates JWT signature itself using JWKS.
 #            Build with the default: ./deploy/opentofu/build.sh
 # "apigw" — API Gateway JWT Authorizer validates; Lambda reads pre-validated claims
 #            from event.requestContext.authorizer.jwt.claims. Build with:
 #            ./deploy/opentofu/build.sh apigatewayv2
+#            Requires api_gateway_type = "http" (JWT Authorizers are HTTP API-only).
 #            SECURITY: Lambda resource policy restricts invocations to the API GW
 #            (source_arn = execution_arn/*/*) — direct invocations are blocked.
 # "alb" mode is NOT supported by this stack — it needs the `alb` Lambda binary

--- a/deploy/opentofu/variables.tf
+++ b/deploy/opentofu/variables.tf
@@ -85,6 +85,66 @@ variable "cross_account" {
   default = { enabled = false }
 }
 
+# ---- Endpoint hardening ----
+variable "api_gateway_type" {
+  type        = string
+  description = <<-EOT
+    API Gateway flavor: 'http' (HTTP API v2, default) or 'rest' (REST API v1).
+    'http' supports the JWT Authorizer (jwt_validation_mode = 'apigw');
+    'rest' supports AWS WAF attachment (enable_waf) for multi-issuer self
+    mode. Both run the same Lambda: 'rest' and 'http'+self use the
+    `apigateway` binary (v1 events; the HTTP API uses payload format 1.0),
+    'http'+apigw uses the `apigatewayv2` binary.
+  EOT
+  default     = "http"
+  validation {
+    condition     = contains(["http", "rest"], var.api_gateway_type)
+    error_message = "api_gateway_type must be 'http' or 'rest'."
+  }
+}
+
+variable "enable_waf" {
+  type        = bool
+  description = <<-EOT
+    Attach an AWS WAFv2 web ACL to the API stage: per-source-IP rate limiting
+    (waf_rate_limit), AWSManagedRulesCommonRuleSet, and a request-shape rule
+    that blocks anything other than POST /verify. Requires api_gateway_type =
+    'rest' (AWS WAF cannot attach to HTTP APIs). No IP allowlisting — GitHub
+    runner IP ranges are vast and dynamic.
+  EOT
+  default     = false
+}
+
+variable "waf_rate_limit" {
+  type        = number
+  description = "WAF rate-based rule: max requests per source IP per 5-minute window. Only used when enable_waf = true."
+  default     = 300
+}
+
+variable "waf_common_rule_set" {
+  type        = bool
+  description = "Include AWSManagedRulesCommonRuleSet in the web ACL. Disable if it false-positives on JWT request bodies. Only used when enable_waf = true."
+  default     = true
+}
+
+variable "throttling_burst_limit" {
+  type        = number
+  description = "API Gateway stage burst limit (concurrent request spikes)."
+  default     = 50
+}
+
+variable "throttling_rate_limit" {
+  type        = number
+  description = "API Gateway stage steady-state rate limit (requests/second)."
+  default     = 100
+}
+
+variable "lambda_reserved_concurrency" {
+  type        = number
+  description = "Reserved concurrent executions for the Lambda — caps the cost/blast radius of unauthenticated floods in self mode. -1 leaves it unreserved."
+  default     = -1
+}
+
 # ---- Lambda sizing ----
 variable "lambda_memory_size" {
   type        = number


### PR DESCRIPTION
## Problem

The OpenTofu stack only provisions an HTTP API (v2), which **cannot attach AWS WAF**. Unknown-issuer tokens are already denied in-app before any JWKS fetch, but in `self` mode every request — valid or junk — still invokes the Lambda, leaving multi-issuer deployments with no pre-invocation protection (invocation cost / DoS vector on a public endpoint).

## Solution

Layered, opt-in hardening with fully backwards-compatible defaults (`http` + existing behavior plans to a no-op):

- **`api_gateway_type = "http" | "rest"`** — new `modules/apigateway-rest` provisions a REST API (v1) for the same `apigateway` binary (v1 events, no rebuild), unlocking WAF attachment.
- **`enable_waf`** (REST only) — WAFv2 web ACL with:
  - per-source-IP rate-based rule (`waf_rate_limit`, default 300 req/5 min)
  - `AWSManagedRulesCommonRuleSet` (toggleable via `waf_common_rule_set`)
  - request-shape rule blocking anything but `POST /verify`
  - deliberately **no IP allowlisting** — GitHub runner IP ranges are vast and dynamic
- **Root-level knobs** for previously buried module settings: `throttling_burst_limit`, `throttling_rate_limit`, `lambda_reserved_concurrency`.
- **Plan-time preconditions** enforce valid combinations: `jwt_validation_mode = "apigw"` ⇒ `http` (JWT authorizers are HTTP API-only); `enable_waf` ⇒ `rest`.
- **Docs**: "Hardening the Public Endpoint" section in `deploy/README.md` (decision rule: single issuer → `apigw` mode; multi-issuer self mode → `rest` + WAF) and matching guidance in `terraform.tfvars.example`.

## Testing

- `tofu fmt -recursive -check` and `tofu validate` pass.
- New `hardening.tftest.hcl` (mock AWS provider, no credentials needed — requires `dist/function.zip` to exist): 4 plan scenarios pass — defaults provision HTTP-only, `rest`+`enable_waf` provisions the REST API + web ACL, and both invalid combinations fail their preconditions.